### PR TITLE
[FEAT] 카카오 소셜 로그인 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
@@ -43,9 +44,13 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	
 	runtimeOnly 'com.h2database:h2'
     testImplementation 'com.h2database:h2'
+
+	implementation "me.paulschwarz:spring-dotenv:4.0.0"
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,10 @@ services:
     depends_on: []  # DB 추가 시: [db]
     networks:
       - app-net
+    redis:
+      image: redis:7-alpine
+      ports:
+        - "6379:6379"
 
   # 선택) MySQL 예시 — 나중에 필요할 때 주석 해제
   # db:

--- a/src/main/java/com/backend/member/controller/MemberController.java
+++ b/src/main/java/com/backend/member/controller/MemberController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 import com.backend.member.domain.Member;
-import com.backend.member.dto.SignUpRequestDTO;
+import com.backend.member.dto.LocalSignUpRequestDTO;
 import com.backend.member.dto.UpdateNicknameRequestDTO;
 import com.backend.member.dto.MemberResponseDTO;
 import com.backend.member.service.MemberService;
@@ -34,15 +34,15 @@ public class MemberController {
 
     @Operation(summary = "회원 가입")
     @PostMapping
-    public ResponseEntity<MemberResponseDTO> signUp(@Valid @RequestBody SignUpRequestDTO req) {
+    public ResponseEntity<MemberResponseDTO> signUp(@Valid @RequestBody LocalSignUpRequestDTO req) {
         Member saved = memberService.signUp(req);
         return ResponseEntity.ok(MemberResponseDTO.from(saved));
     }
 
     @Operation(summary = "회원 단일 조회")
     @GetMapping("/{id}")
-    public ResponseEntity<MemberResponseDTO> get(@PathVariable Long id) {
-        Member found = memberService.get(id);
+    public ResponseEntity<MemberResponseDTO> get(@PathVariable String userId) {
+        Member found = memberService.getByUserId(userId);
         return ResponseEntity.ok(MemberResponseDTO.from(found));
     }
 
@@ -61,8 +61,8 @@ public class MemberController {
         @AuthenticationPrincipal CustomUserPrincipal me,
         @Valid @RequestBody UpdateNicknameRequestDTO req
     ) {
-        Long myId = me.getMemberId();
-        Member updated = memberService.changeNickname(myId, req);
+        String myUserId = me.getUserId();
+        Member updated = memberService.changeNicknameByUserId(myUserId, req);
         return ResponseEntity.ok(MemberResponseDTO.from(updated));
     }
     
@@ -71,17 +71,16 @@ public class MemberController {
     public ResponseEntity<Void> deleteMe(
         @AuthenticationPrincipal CustomUserPrincipal me
     ) {
-        Long myId = me.getMemberId();
-        memberService.delete(myId);
+        String myUserId = me.getUserId();
+        memberService.deleteByUserId(myUserId);
         return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "내 정보 조회")
     @GetMapping("/me")
-    public ResponseEntity<MemberResponseDTO> getMe(
-        @AuthenticationPrincipal CustomUserPrincipal me
-    ) {
-        Member found = memberService.get(me.getMemberId());
+    public ResponseEntity<MemberResponseDTO> getMe(@AuthenticationPrincipal CustomUserPrincipal me) {
+        if (me == null) return ResponseEntity.status(401).build();
+        Member found = memberService.getByUserId(me.getUserId());
         return ResponseEntity.ok(MemberResponseDTO.from(found));
     }
 }

--- a/src/main/java/com/backend/member/domain/Member.java
+++ b/src/main/java/com/backend/member/domain/Member.java
@@ -1,57 +1,130 @@
 package com.backend.member.domain;
 
 import jakarta.persistence.*;
-// 이메일 형식 검증용
 import jakarta.validation.constraints.Email;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-/**
- * Member 엔티티
- * - 회원 정보를 저장하는 도메인 객체
- * - BaseTimeEntity를 상속하여 생성/수정 시각을 자동 관리함
- */
-@Entity
-@Table(name = "members", indexes = {
-        @Index(name = "idx_member_email_unique", columnList = "email", unique = true)
-})
+import java.util.UUID;
+
 @Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@Entity
+@Table(
+    name = "members",
+    indexes = {
+        @Index(name = "idx_member_email_unique", columnList = "email", unique = true),
+        @Index(name = "idx_member_user_id_unique", columnList = "user_id", unique = true),
+        @Index(name = "idx_member_social", columnList = "social_provider,social_id")
+    },
+    uniqueConstraints = {
+        // 소셜 로그인 고유성 보장 (provider + social_id)
+        @UniqueConstraint(name = "uk_member_social_provider_id", columnNames = {"social_provider", "social_id"})
+    }
+)
 public class Member {
 
+    // 내부 PK (DB 관계용)
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    // 외부 공개용 안정적 식별자
+    @Column(name = "user_id", nullable = false, unique = true, length = 36)
+    private String userId;
+
+    /** 이메일 (LOCAL/소셜 공통, 비즈니스 정책상 필수로 유지) */
     @Email
     @Column(nullable = false, unique = true, length = 255)
     private String email;
 
+    /** 비밀번호(BCrypt 60자). 소셜 계정은 더미 해시 저장 가능 */
     @Column(nullable = false, length = 60)
     private String password;
 
+    /** 닉네임 */
     @Column(nullable = false, length = 50)
     private String nickname;
 
+    /** 권한 */
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
-    private Role role = Role.USER;  // 기본값 USER
+    private Role role = Role.USER;
 
-    protected Member() {} // JPA 기본 생성자
+    /** 소셜 로그인 제공자 (KAKAO 등). LOCAL이면 null */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "social_provider", length = 20)
+    private SocialProvider socialProvider;
+
+    /** 소셜 식별자 — provider와 함께 유니크 */
+    @Column(name = "social_id", length = 100)
+    private String socialId;
+
+    /** 프로필 이미지 URL */
+    @Column(name = "profile", length = 500)
+    private String profile;
+
+    /** 전화번호 */
+    @Column(name = "phone", length = 30)
+    private String phone;
+
+    /** 생성 시 userId 자동 채번 (없으면 UUID) */
+    @PrePersist
+    private void ensureUserId() {
+        if (this.userId == null || this.userId.isBlank()) {
+            this.userId = UUID.randomUUID().toString();
+        }
+    }
 
     @Builder
-    private Member(String email, String rawEncodedPassword, String nickname, Role role) {
+    private Member(
+            String userId,
+            String email,
+            String password,
+            String nickname,
+            Role role,
+            SocialProvider socialProvider,
+            String socialId,
+            String profile,
+            String phone
+    ) {
+        this.userId = userId; // null이면 @PrePersist에서 UUID 채움
         this.email = email;
-        this.password = rawEncodedPassword;
+        this.password = password;
         this.nickname = nickname;
-        this.role = role;
+        if (role != null) this.role = role;
+        this.socialProvider = socialProvider;
+        this.socialId = socialId;
+        this.profile = profile;
+        this.phone = phone;
     }
 
-    public static Member of(String email, String encodedPassword, String nickname) {
-        return new Member(email, encodedPassword, nickname, Role.USER);
+    /** LOCAL 회원 생성 헬퍼 */
+    public static Member local(String userId, String email, String encodedPassword, String nickname) {
+        return Member.builder()
+                .userId(userId)                 // null 전달 시 @PrePersist가 UUID 생성
+                .email(email)
+                .password(encodedPassword)
+                .nickname(nickname)
+                .role(Role.USER)
+                .build();
     }
 
+    /** 소셜 회원 생성 헬퍼 (비밀번호는 더미 해시/랜덤) */
+    public static Member social(SocialProvider provider, String socialId, String email, String encodedDummyPwd, String nickname) {
+        return Member.builder()
+                .email(email)
+                .password(encodedDummyPwd)
+                .nickname(nickname)
+                .role(Role.USER)
+                .socialProvider(provider)
+                .socialId(socialId)
+                .build();
+    }
 
-    // ------------- business logic -------------
-    // nickname 변경
+    // 변경 메서드
     public void changeNickname(String nickname) { this.nickname = nickname; }
     public void changeRole(Role role) { this.role = role; }
+    public void changeProfile(String profile) { this.profile = profile; }
+    public void changePhone(String phone) { this.phone = phone; }
 }

--- a/src/main/java/com/backend/member/domain/SocialProvider.java
+++ b/src/main/java/com/backend/member/domain/SocialProvider.java
@@ -1,0 +1,7 @@
+package com.backend.member.domain;
+
+// 추후 확장 가능성
+public enum SocialProvider {
+    LOCAL,
+    KAKAO
+}

--- a/src/main/java/com/backend/member/dto/LocalSignUpRequestDTO.java
+++ b/src/main/java/com/backend/member/dto/LocalSignUpRequestDTO.java
@@ -4,8 +4,9 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-public record SignUpRequestDTO(
+public record LocalSignUpRequestDTO(
         @Email @NotBlank String email,
         @NotBlank @Size(min = 8, max = 64) String password,
-        @NotBlank @Size(min = 2, max = 50) String nickname
+        String nickname,
+        String phone
 ) {}

--- a/src/main/java/com/backend/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/backend/member/dto/MemberResponseDTO.java
@@ -4,12 +4,17 @@ import com.backend.member.domain.Member;
 import com.backend.member.domain.Role;
 
 public record MemberResponseDTO(
-        Long id,
+        String userId,
         String email,
         String nickname,
         Role role
 ) {
     public static MemberResponseDTO from(Member m) {
-        return new MemberResponseDTO(m.getId(), m.getEmail(), m.getNickname(), m.getRole());
+        return new MemberResponseDTO(
+                m.getUserId(),
+                m.getEmail(),
+                m.getNickname(),
+                m.getRole()
+        );
     }
 }

--- a/src/main/java/com/backend/member/repository/MemberRepository.java
+++ b/src/main/java/com/backend/member/repository/MemberRepository.java
@@ -4,8 +4,20 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.backend.member.domain.Member;
+import com.backend.member.domain.SocialProvider;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    /** 이메일 기반 조회 (LOCAL/소셜 공통) */
     Optional<Member> findByEmail(String email);
+
+    /** userId(UUID) 기반 조회 — JWT, 외부 시스템 식별용 */
+    Optional<Member> findByUserId(String userId);
+
+    /** 소셜 로그인용 복합 키 조회 */
+    Optional<Member> findBySocialProviderAndSocialId(SocialProvider provider, String socialId);
+
+    /** 존재 여부 검사 */
     boolean existsByEmail(String email);
+    boolean existsByUserId(String userId);
+    boolean existsBySocialProviderAndSocialId(SocialProvider provider, String socialId);
 }

--- a/src/main/java/com/backend/member/service/KakaoAuthService.java
+++ b/src/main/java/com/backend/member/service/KakaoAuthService.java
@@ -1,0 +1,48 @@
+package com.backend.member.service;
+
+import com.backend.member.domain.Member;
+import com.backend.member.domain.SocialProvider;
+import com.backend.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoAuthService {
+
+    private final MemberRepository memberRepo;
+    private final PasswordEncoder encoder;
+
+    /**
+     * 소셜 사용자 upsert: (provider, socialId)가 존재하면 업데이트, 없으면 신규 생성
+     * - password: 소셜은 로그인에 쓰지 않지만 null 금지를 위해 더미 해시 저장
+     */
+    @Transactional
+    public Member upsertKakaoUser(String socialId, String email, String nickname, String profileImageUrl) {
+        return memberRepo.findBySocialProviderAndSocialId(SocialProvider.KAKAO, socialId)
+                .map(m -> {
+                    // 이메일/프로필/닉네임 최신화(필요시)
+                    if (email != null && !email.equals(m.getEmail())) {
+                        // 이메일 unique라 변경 시 유효성 체크 필요 (케이스에 따라 유지 권장)
+                    }
+                    if (nickname != null) m.changeNickname(nickname);
+                    if (profileImageUrl != null) m.changeProfile(profileImageUrl);
+                    return m;
+                })
+                .orElseGet(() -> {
+                    String dummy = encoder.encode("kakao_" + socialId); // 더미 해시
+                    // Member.social(...) 팩토리 사용 (이전에 만들어둔 메서드)
+                    return memberRepo.save(
+                            Member.social(
+                                    com.backend.member.domain.SocialProvider.KAKAO,
+                                    socialId,
+                                    email != null ? email : ("kakao-" + socialId + "@example.com"),
+                                    dummy,
+                                    nickname != null ? nickname : "kakao_user"
+                            )
+                    );
+                });
+    }
+}

--- a/src/main/java/com/backend/member/service/MemberService.java
+++ b/src/main/java/com/backend/member/service/MemberService.java
@@ -2,7 +2,7 @@ package com.backend.member.service;
 
 import com.backend.member.domain.Member;
 import com.backend.member.domain.Role;
-import com.backend.member.dto.SignUpRequestDTO;
+import com.backend.member.dto.LocalSignUpRequestDTO;
 import com.backend.member.dto.UpdateNicknameRequestDTO;
 import com.backend.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,26 +21,40 @@ public class MemberService {
     private final PasswordEncoder encoder;
 
     /**
-     * 회원가입 (쓰기 작업이므로 readOnly=false)
+     * 로컬 회원가입
      */
     @Transactional
-    public Member signUp(SignUpRequestDTO req) {
+    public Member signUp(LocalSignUpRequestDTO req) {
         if (repo.existsByEmail(req.email())) {
             throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
         }
 
         String encodedPw = encoder.encode(req.password());
-        Member member = Member.of(req.email(), encodedPw, req.nickname());
+
+        // UUID userId는 @PrePersist에서 자동 생성됨
+        Member member = Member.local(
+                null,               // userId (null → 자동 UUID)
+                req.email(),
+                encodedPw,
+                req.nickname()
+        );
 
         return repo.save(member);
     }
 
     /**
+     * 소셜 회원가입 (카카오 등)
+     */
+
+
+
+
+    /**
      * 회원 단일 조회 (readOnly 트랜잭션)
      */
-    public Member get(Long id) {
-        return repo.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원"));
+    public Member getByUserId(String userId) {
+        return repo.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
     }
 
     /**
@@ -54,22 +68,20 @@ public class MemberService {
      * 닉네임 변경 (쓰기 작업)
      */
     @Transactional
-    public Member changeNickname(Long myId, UpdateNicknameRequestDTO req) {
-        Member m = repo.findById(myId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원"));
-
+    public Member changeNicknameByUserId(String userId, UpdateNicknameRequestDTO req) {
+        Member m = repo.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
         m.changeNickname(req.nickname());
-        return m; // JPA Dirty Checking으로 자동 업데이트
+        return m;
     }
 
     /**
      * 관리자 승격 (어드민 기능)
      */
     @Transactional
-    public Member promoteToAdmin(Long id) {
-        Member m = repo.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원"));
-
+    public Member promoteToAdmin(String userId) {
+        Member m = repo.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
         m.changeRole(Role.ADMIN);
         return m;
     }
@@ -78,7 +90,9 @@ public class MemberService {
      * 회원 삭제
      */
     @Transactional
-    public void delete(Long myId) {
-        repo.deleteById(myId);
+    public void deleteByUserId(String userId) {
+        Member m = repo.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+        repo.delete(m);
     }
 }

--- a/src/main/java/com/backend/member/service/MemberService.java
+++ b/src/main/java/com/backend/member/service/MemberService.java
@@ -43,13 +43,6 @@ public class MemberService {
     }
 
     /**
-     * 소셜 회원가입 (카카오 등)
-     */
-
-
-
-
-    /**
      * 회원 단일 조회 (readOnly 트랜잭션)
      */
     public Member getByUserId(String userId) {

--- a/src/main/java/com/backend/security/auth/blacklist/TokenBlacklistService.java
+++ b/src/main/java/com/backend/security/auth/blacklist/TokenBlacklistService.java
@@ -1,0 +1,36 @@
+package com.backend.security.auth.blacklist;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/** 기본 인터페이스 */
+public interface TokenBlacklistService {
+    void blacklist(String jti, Duration ttl);
+    boolean isBlacklisted(String jti);
+}
+
+@Service
+class RedisTokenBlacklistService implements TokenBlacklistService {
+
+    private final StringRedisTemplate redis;
+
+    public RedisTokenBlacklistService(StringRedisTemplate redis) {
+        this.redis = redis;
+    }
+
+    private String key(String jti) { return "jwt:blacklist:" + jti; }
+
+    @Override
+    public void blacklist(String jti, Duration ttl) {
+        Objects.requireNonNull(jti);
+        redis.opsForValue().set(key(jti), "1", ttl);
+    }
+
+    @Override
+    public boolean isBlacklisted(String jti) {
+        return Boolean.TRUE.equals(redis.hasKey(key(jti)));
+    }
+}

--- a/src/main/java/com/backend/security/auth/controller/AuthController.java
+++ b/src/main/java/com/backend/security/auth/controller/AuthController.java
@@ -21,6 +21,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Set;
 import java.time.Instant;
@@ -87,12 +88,12 @@ public class AuthController {
                 .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 리프레시 토큰입니다."));
 
         if (saved.isExpired()) {
-            refreshRepo.deleteByMemberId(saved.getMemberId()); // 만료된 기록 정리
+            refreshRepo.deleteByUserId(saved.getUserId()); // 만료된 기록 정리
             return unauthorized("invalid_token", "refresh token expired");
         }
 
         // 3) 주인(Member) 확인 후 새 토큰 세트 발급(+DB 로테이션)
-        Member owner = memberRepo.findById(saved.getMemberId())
+        Member owner = memberRepo.findByUserId(saved.getUserId())
                 .orElseThrow(() -> new IllegalStateException("해당 사용자가 존재하지 않습니다."));
 
         TokenResponseDTO newSet = authTokenService.issueTokensFor(owner); // 기존 레코드가 로테이션됨
@@ -101,6 +102,7 @@ public class AuthController {
 
     @Operation(summary = "로그아웃 → Access 블랙리스트 등록 + Refresh 제거")
     @PostMapping("/logout")
+    @Transactional
     public ResponseEntity<Void> logout(
             @RequestHeader(value = "Authorization", required = false) String authorizationHeader) {
     
@@ -143,9 +145,9 @@ public class AuthController {
         // 4) Redis 블랙리스트 등록
         blacklist.blacklist(jti, ttl);
     
-        // 5) 토큰 subject(=memberId)로 refresh 기록 제거
-        Long memberId = Long.parseLong(tokenProvider.getSubject(accessToken));
-        refreshRepo.deleteByMemberId(memberId);
+        // 5) 토큰 subject(=userId)로 refresh 기록 제거
+        String userId = tokenProvider.getSubject(accessToken);
+        refreshRepo.deleteByUserId(userId);
     
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/backend/security/auth/controller/AuthController.java
+++ b/src/main/java/com/backend/security/auth/controller/AuthController.java
@@ -1,22 +1,31 @@
 package com.backend.security.auth.controller;
 
+import com.backend.member.domain.Member;
+import com.backend.member.repository.MemberRepository;
 import com.backend.security.auth.domain.RefreshToken;
 import com.backend.security.auth.dto.LoginRequestDTO;
 import com.backend.security.auth.dto.RefreshRequestDTO;
 import com.backend.security.auth.dto.TokenResponseDTO;
 import com.backend.security.auth.jwt.JwtTokenProvider;
+import com.backend.security.auth.jwt.JwtValidationResult;
 import com.backend.security.auth.repository.RefreshTokenRepository;
 import com.backend.security.auth.service.AuthTokenService;
-import com.backend.member.domain.Member;
-import com.backend.member.repository.MemberRepository;
+import com.backend.security.auth.blacklist.TokenBlacklistService;
+import com.backend.security.util.HashUtil;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Set;
+import java.time.Instant;
+import java.time.Duration;
+import java.util.Optional;
 
 @Tag(name = "Auth", description = "인증 API (JWT + Refresh)")
 @RestController
@@ -27,23 +36,23 @@ public class AuthController {
     private final RefreshTokenRepository refreshRepo;
     private final PasswordEncoder encoder;
     private final JwtTokenProvider tokenProvider;
-    private final AuthTokenService authTokenService; // ✅ 새로 주입
+    private final AuthTokenService authTokenService;
+    private final TokenBlacklistService blacklist;
 
     public AuthController(MemberRepository memberRepo,
                           RefreshTokenRepository refreshRepo,
                           PasswordEncoder encoder,
                           JwtTokenProvider tokenProvider,
-                          AuthTokenService authTokenService) {
+                          AuthTokenService authTokenService,
+                          TokenBlacklistService blacklist) {
         this.memberRepo = memberRepo;
         this.refreshRepo = refreshRepo;
         this.encoder = encoder;
         this.tokenProvider = tokenProvider;
         this.authTokenService = authTokenService;
+        this.blacklist = blacklist;
     }
 
-    /**
-     * ✅ 로그인 - 사용자 검증 후 access/refresh 발급 (AuthTokenService에 위임)
-     */
     @Operation(summary = "로그인 → Access/Refresh 동시 발급")
     @PostMapping("/login")
     public ResponseEntity<TokenResponseDTO> login(@Valid @RequestBody LoginRequestDTO req) {
@@ -54,48 +63,96 @@ public class AuthController {
             throw new IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다.");
         }
 
-        // ✅ AuthTokenService가 토큰 발급 + 저장까지 처리
-        TokenResponseDTO tokenSet = authTokenService.issueTokensFor(m);
-        return ResponseEntity.ok(tokenSet);
+        // 토큰 발급 + 저장(로테이션) 공통 로직
+        return ResponseEntity.ok(authTokenService.issueTokensFor(m));
     }
 
-    /**
-     * ✅ 토큰 재발급 (Refresh → Access 교체)
-     */
     @Operation(summary = "재발급 → Access 교체, Refresh 로테이션(보안 권장)")
     @PostMapping("/refresh")
     public ResponseEntity<TokenResponseDTO> refresh(@Valid @RequestBody RefreshRequestDTO req) {
-        String oldRefresh = req.refreshToken();
+        final String oldRefresh = req.refreshToken();
+        String oldRefreshHash = HashUtil.sha256Base64(oldRefresh);
 
-        // 1) refresh 유효성 검사
-        if (!tokenProvider.validate(oldRefresh)) {
-            return ResponseEntity.status(401).build();
+        // 1) JWT 자체 유효성 + 발급자/대상자 + 형식 검사
+        JwtValidationResult vr = tokenProvider.validateAndClassify(oldRefresh, Set.of("web")); // audience 정책에 맞게
+        if (vr != JwtValidationResult.OK) {
+            return unauthorized("invalid_token", "refresh token validation failed: " + vr);
+        }
+        if (!tokenProvider.isRefreshToken(oldRefresh)) { // typ == "refresh" 검사 (provider에 추가해 둔 메서드)
+            return unauthorized("invalid_token", "token is not a refresh token");
         }
 
-        // 2) 저장된 refresh 확인
-        RefreshToken saved = refreshRepo.findByToken(oldRefresh)
+        // 2) 서버 저장소에 실제 존재하는 refresh 인지 확인 (도난/폐기 토큰 차단)
+        RefreshToken saved = refreshRepo.findByTokenHash(oldRefreshHash)
                 .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 리프레시 토큰입니다."));
 
         if (saved.isExpired()) {
-            refreshRepo.deleteByEmail(saved.getEmail());
-            return ResponseEntity.status(401).build();
+            refreshRepo.deleteByMemberId(saved.getMemberId()); // 만료된 기록 정리
+            return unauthorized("invalid_token", "refresh token expired");
         }
 
-        // 3) 새 토큰 세트 발급 (공통 로직 재사용)
-        Member m = memberRepo.findByEmail(saved.getEmail())
+        // 3) 주인(Member) 확인 후 새 토큰 세트 발급(+DB 로테이션)
+        Member owner = memberRepo.findById(saved.getMemberId())
                 .orElseThrow(() -> new IllegalStateException("해당 사용자가 존재하지 않습니다."));
 
-        TokenResponseDTO newTokenSet = authTokenService.issueTokensFor(m);
-        return ResponseEntity.ok(newTokenSet);
+        TokenResponseDTO newSet = authTokenService.issueTokensFor(owner); // 기존 레코드가 로테이션됨
+        return ResponseEntity.ok(newSet);
     }
 
-    /**
-     * ✅ 로그아웃 - refresh token 제거
-     */
-    @Operation(summary = "로그아웃 → 서버 저장된 Refresh 제거 (Access는 자연 만료)")
+    @Operation(summary = "로그아웃 → Access 블랙리스트 등록 + Refresh 제거")
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(@RequestParam String email) {
-        refreshRepo.deleteByEmail(email);
+    public ResponseEntity<Void> logout(
+            @RequestHeader(value = "Authorization", required = false) String authorizationHeader) {
+    
+        // 0) Authorization 헤더 존재 & 형식 확인
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            return ResponseEntity.status(401)
+                    .header(HttpHeaders.WWW_AUTHENTICATE, "Bearer error=\"invalid_token\", error_description=\"missing or malformed Authorization header\"")
+                    .build();
+        }
+    
+        final String accessToken = authorizationHeader.substring(7).trim();
+    
+        // 1) 토큰 유효성 (+audience) & 타입(access) 확인
+        JwtValidationResult vr = tokenProvider.validateAndClassify(accessToken, Set.of("web"));
+        if (vr != JwtValidationResult.OK || !tokenProvider.isAccessToken(accessToken)) {
+            return ResponseEntity.status(401)
+                    .header(HttpHeaders.WWW_AUTHENTICATE, "Bearer error=\"invalid_token\", error_description=\"access token validation failed: " + vr + "\"")
+                    .build();
+        }
+    
+        // 2) jti 추출
+        Optional<String> jtiOpt = tokenProvider.tryGetJti(accessToken);
+        if (jtiOpt.isEmpty()) {
+            return ResponseEntity.status(401)
+                    .header(HttpHeaders.WWW_AUTHENTICATE, "Bearer error=\"invalid_token\", error_description=\"missing jti\"")
+                    .build();
+        }
+        String jti = jtiOpt.get();
+    
+        // 3) 남은 TTL 계산 (음수/0 방지)
+        Instant now = Instant.now();
+        Instant exp = tokenProvider.getExpiresAt(accessToken).toInstant();
+        Duration ttl = Duration.between(now, exp);
+        if (!ttl.isNegative() && !ttl.isZero()) {
+            // 정상 TTL
+        } else {
+            ttl = Duration.ofSeconds(1);
+        }
+    
+        // 4) Redis 블랙리스트 등록
+        blacklist.blacklist(jti, ttl);
+    
+        // 5) 토큰 subject(=memberId)로 refresh 기록 제거
+        Long memberId = Long.parseLong(tokenProvider.getSubject(accessToken));
+        refreshRepo.deleteByMemberId(memberId);
+    
         return ResponseEntity.noContent().build();
+    }
+
+    private ResponseEntity<TokenResponseDTO> unauthorized(String code, String desc) {
+        return ResponseEntity.status(401)
+                .header(HttpHeaders.WWW_AUTHENTICATE, "Bearer error=\"" + code + "\", error_description=\"" + desc + "\"")
+                .body(null);
     }
 }

--- a/src/main/java/com/backend/security/auth/controller/KakaoAuthController.java
+++ b/src/main/java/com/backend/security/auth/controller/KakaoAuthController.java
@@ -1,0 +1,68 @@
+package com.backend.security.auth.controller;
+
+import com.backend.member.domain.Member;
+import com.backend.member.service.KakaoAuthService;
+import com.backend.security.auth.dto.TokenResponseDTO;
+import com.backend.security.auth.service.AuthTokenService;
+import com.backend.security.oauth.kakao.KakaoOAuthClient;
+import com.backend.security.oauth.kakao.dto.KakaoAccessTokenLoginRequestDTO;
+import com.backend.security.oauth.kakao.dto.KakaoLoginRequestDTO;
+import com.backend.security.oauth.kakao.dto.KakaoTokenResponseDTO;
+import com.backend.security.oauth.kakao.dto.KakaoUserResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "SocialAuth", description = "카카오 소셜 로그인")
+@RestController
+@RequestMapping("/api/auth/oauth/kakao")
+public class KakaoAuthController {
+
+    private final KakaoOAuthClient kakao;
+    private final KakaoAuthService socialAuthService;
+    private final AuthTokenService authTokenService;
+
+    public KakaoAuthController(KakaoOAuthClient kakao,
+                                KakaoAuthService socialAuthService,
+                                AuthTokenService authTokenService) {
+        this.kakao = kakao;
+        this.socialAuthService = socialAuthService;
+        this.authTokenService = authTokenService;
+    }
+
+    @Operation(summary = "[서버 사이드] 인가코드로 카카오 로그인")
+    @PostMapping("/login-by-code")
+    public ResponseEntity<TokenResponseDTO> loginByCode(@Valid @RequestBody KakaoLoginRequestDTO req) {
+        KakaoTokenResponseDTO token = kakao.exchangeCodeForToken(req.code());
+        KakaoUserResponseDTO user = kakao.fetchUser(token.accessToken());
+
+        String socialId = String.valueOf(user.id());
+        String email = user.kakaoAccount() != null ? user.kakaoAccount().email() : null;
+        String nickname = (user.kakaoAccount() != null && user.kakaoAccount().profile() != null)
+                ? user.kakaoAccount().profile().nickname() : null;
+        String profile = (user.kakaoAccount() != null && user.kakaoAccount().profile() != null)
+                ? user.kakaoAccount().profile().profileImageUrl() : null;
+
+        Member m = socialAuthService.upsertKakaoUser(socialId, email, nickname, profile);
+        return ResponseEntity.ok(authTokenService.issueTokensFor(m));
+    }
+
+    @Operation(summary = "[프론트/모바일] 카카오 access_token으로 로그인")
+    @PostMapping("/login-by-token")
+    public ResponseEntity<TokenResponseDTO> loginByToken(@Valid @RequestBody KakaoAccessTokenLoginRequestDTO req) {
+        KakaoUserResponseDTO user = kakao.fetchUser(req.kakaoAccessToken());
+
+        String socialId = String.valueOf(user.id());
+        String email = user.kakaoAccount() != null ? user.kakaoAccount().email() : null;
+        String nickname = (user.kakaoAccount() != null && user.kakaoAccount().profile() != null)
+                ? user.kakaoAccount().profile().nickname() : null;
+        String profile = (user.kakaoAccount() != null && user.kakaoAccount().profile() != null)
+                ? user.kakaoAccount().profile().profileImageUrl() : null;
+
+        Member m = socialAuthService.upsertKakaoUser(socialId, email, nickname, profile);
+        return ResponseEntity.ok(authTokenService.issueTokensFor(m));
+    }
+    
+}

--- a/src/main/java/com/backend/security/auth/controller/KakaoLoginPageController.java
+++ b/src/main/java/com/backend/security/auth/controller/KakaoLoginPageController.java
@@ -1,0 +1,34 @@
+package com.backend.security.auth.controller;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import jakarta.annotation.PostConstruct;
+
+@Controller
+public class KakaoLoginPageController {
+    
+    @PostConstruct
+    public void checkKeys() {
+        System.out.println("[KAKAO] clientId=" + clientId);
+        System.out.println("[KAKAO] redirectUri=" + redirectUri);
+    }
+
+    @Value("${app.oauth.kakao.client-id:dummy}")
+    private String clientId;
+
+    @Value("${app.oauth.kakao.redirect-uri:http://localhost:8080/api/auth/oauth/kakao/callback}")
+    private String redirectUri;
+
+    @GetMapping("/page")
+    public String loginPage(Model model) {
+        String location = "https://kauth.kakao.com/oauth/authorize"
+                + "?response_type=code"
+                + "&client_id=" + clientId
+                + "&redirect_uri=" + redirectUri;
+        model.addAttribute("location", location);
+        return "login"; // templates/login.html
+    }
+}

--- a/src/main/java/com/backend/security/auth/controller/LocalAuthController.java
+++ b/src/main/java/com/backend/security/auth/controller/LocalAuthController.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 @Tag(name = "Auth", description = "인증 API (JWT + Refresh)")
 @RestController
 @RequestMapping("/api/auth")
-public class AuthController {
+public class LocalAuthController {
 
     private final MemberRepository memberRepo;
     private final RefreshTokenRepository refreshRepo;
@@ -40,7 +40,7 @@ public class AuthController {
     private final AuthTokenService authTokenService;
     private final TokenBlacklistService blacklist;
 
-    public AuthController(MemberRepository memberRepo,
+    public LocalAuthController(MemberRepository memberRepo,
                           RefreshTokenRepository refreshRepo,
                           PasswordEncoder encoder,
                           JwtTokenProvider tokenProvider,

--- a/src/main/java/com/backend/security/auth/domain/RefreshToken.java
+++ b/src/main/java/com/backend/security/auth/domain/RefreshToken.java
@@ -2,44 +2,44 @@ package com.backend.security.auth.domain;
 
 import jakarta.persistence.*;
 import java.time.Instant;
+import lombok.Getter;
 
 @Entity
 @Table(name = "refresh_tokens", indexes = {
-        @Index(name = "idx_refresh_email_unique", columnList = "email", unique = true),
-        @Index(name = "idx_refresh_token", columnList = "token")
+        @Index(name = "idx_refresh_member", columnList = "memberId", unique = true),
+        @Index(name = "idx_refresh_token", columnList = "tokenHash", unique = true)
 })
+
+@Getter
 public class RefreshToken {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable=false, unique = true, length = 255)
-    private String email;
+    @Column(nullable = false)
+    private Long memberId;
 
     @Column(nullable=false, length = 500)
-    private String token;
+    private String tokenHash;
 
     @Column(nullable=false)
     private Instant expiresAt;
 
     protected RefreshToken() {}
 
-    public RefreshToken(String email, String token, Instant expiresAt) {
-        this.email = email;
-        this.token = token;
+    public RefreshToken(Long memberId, String tokenHash, Instant expiresAt) {
+        this.memberId = memberId;
+        this.tokenHash = tokenHash;
         this.expiresAt = expiresAt;
     }
 
-    public Long getId() { return id; }
-    public String getEmail() { return email; }
-    public String getToken() { return token; }
-    public Instant getExpiresAt() { return expiresAt; }
-
-    public void rotate(String newToken, Instant newExpiry) {
-        this.token = newToken;
-        this.expiresAt = newExpiry;
+    public void rotate(String newHash, Instant newExp) {
+        this.tokenHash = newHash;
+        this.expiresAt = newExp;
     }
 
-    public boolean isExpired() { return Instant.now().isAfter(this.expiresAt); }
+    public boolean isExpired() {
+        return Instant.now().isAfter(expiresAt);
+    }
 }

--- a/src/main/java/com/backend/security/auth/domain/RefreshToken.java
+++ b/src/main/java/com/backend/security/auth/domain/RefreshToken.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Entity
 @Table(name = "refresh_tokens", indexes = {
-        @Index(name = "idx_refresh_member", columnList = "memberId", unique = true),
+        @Index(name = "idx_refresh_member", columnList = "userId", unique = true),
         @Index(name = "idx_refresh_token", columnList = "tokenHash", unique = true)
 })
 
@@ -18,7 +18,7 @@ public class RefreshToken {
     private Long id;
 
     @Column(nullable = false)
-    private Long memberId;
+    private String userId;
 
     @Column(nullable=false, length = 500)
     private String tokenHash;
@@ -28,8 +28,8 @@ public class RefreshToken {
 
     protected RefreshToken() {}
 
-    public RefreshToken(Long memberId, String tokenHash, Instant expiresAt) {
-        this.memberId = memberId;
+    public RefreshToken(String userId, String tokenHash, Instant expiresAt) {
+        this.userId = userId;
         this.tokenHash = tokenHash;
         this.expiresAt = expiresAt;
     }

--- a/src/main/java/com/backend/security/auth/dto/LoginRequestDTO.java
+++ b/src/main/java/com/backend/security/auth/dto/LoginRequestDTO.java
@@ -2,12 +2,15 @@ package com.backend.security.auth.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-
+import jakarta.validation.constraints.Pattern;
 /**
  * 로그인 요청 DTO
  * - 이메일 / 비밀번호를 전달받음
  */
 public record LoginRequestDTO(
         @Email @NotBlank String email,
-        @NotBlank String password
+        @NotBlank
+        @Pattern(regexp="^(?=.*[A-Za-z])(?=.*\\d).{8,64}$",
+                 message="비밀번호는 8~64자, 영문/숫자 포함")
+        String password
 ) {}

--- a/src/main/java/com/backend/security/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/backend/security/auth/jwt/JwtAuthenticationFilter.java
@@ -1,36 +1,101 @@
 package com.backend.security.auth.jwt;
 
+import com.backend.security.auth.blacklist.TokenBlacklistService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpHeaders;
+import org.springframework.lang.NonNull;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import org.springframework.lang.NonNull;
+import java.util.Set;
 
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider tokenProvider;
-    public JwtAuthenticationFilter(JwtTokenProvider tokenProvider) { this.tokenProvider = tokenProvider; }
+    private final TokenBlacklistService blacklist;
+
+    // 필요 시 허용 audience를 외부에서 주입하고 싶으면 생성자 인자에 Set<String> 추가해서 사용
+    private final Set<String> acceptedAudiences;
+
+    public JwtAuthenticationFilter(JwtTokenProvider tokenProvider,
+                                   TokenBlacklistService blacklist) {
+        this(tokenProvider, blacklist, null);
+    }
+
+    public JwtAuthenticationFilter(JwtTokenProvider tokenProvider,
+                                   TokenBlacklistService blacklist,
+                                   Set<String> acceptedAudiences) {
+        this.tokenProvider = tokenProvider;
+        this.blacklist = blacklist;
+        this.acceptedAudiences = acceptedAudiences;
+    }
 
     @Override
     protected void doFilterInternal(
-        @NonNull HttpServletRequest req,
-        @NonNull HttpServletResponse res,
-        @NonNull FilterChain chain
+            @NonNull HttpServletRequest req,
+            @NonNull HttpServletResponse res,
+            @NonNull FilterChain chain
     ) throws ServletException, IOException {
+
+        System.out.println(">>> [JWT FILTER] " + req.getMethod() + " " + req.getRequestURI());
+
         String auth = req.getHeader(HttpHeaders.AUTHORIZATION);
         if (auth != null && auth.startsWith("Bearer ")) {
-            String token = auth.substring(7);
-            if (tokenProvider.validate(token)) {
+            String token = auth.substring(7).trim();
+
+            // 0) 블랙리스트(JTI) 선확인 (jti 파싱 실패 시 아래 검증에서 걸림)
+            try {
+                String jti = tokenProvider.tryGetJti(token).orElse(null);
+                if (jti != null && blacklist.isBlacklisted(jti)) {
+                    req.setAttribute("jwt.error", "blacklisted");
+                    // 인증 세팅 없이 통과 -> 이후 인가 단계에서 401/403
+                    chain.doFilter(req, res);
+                    return;
+                }
+            } catch (Exception ignore) {
+                // 계속 진행해서 표준 검증 로직으로 사유 설정
+            }
+
+            // 1) 상세 검증 (서명, 만료, iss/aud 등)
+            JwtValidationResult result = (acceptedAudiences == null)
+                    ? tokenProvider.validateAndClassify(token)
+                    : tokenProvider.validateAndClassify(token, acceptedAudiences);
+            if (result == JwtValidationResult.OK) {
+
+                // 2) refresh 토큰을 Authorization에 들고 오는 오남용 방지
+                if (!tokenProvider.isAccessToken(token)) {
+                    req.setAttribute("jwt.error", "refresh-token-not-allowed-in-authorization");
+                    chain.doFilter(req, res);
+                    return;
+                }
+
+                // 3) 인증 컨텍스트 세팅
                 Authentication authentication = tokenProvider.getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            } else {
+                // 실패 사유를 리퀘스트에 남겨서 ErrorHandlingFilter 또는 EntryPoint에서 메시지 제어 가능
+                req.setAttribute("jwt.error", result.name().toLowerCase());
             }
         }
+
         chain.doFilter(req, res);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(@NonNull HttpServletRequest request) {
+        // 공개/예외 경로는 필터 스킵
+        String p = request.getRequestURI();
+        return p.startsWith("/healthz")
+            || p.startsWith("/swagger-ui")
+            || p.startsWith("/v3/api-docs")
+            || p.startsWith("/api/auth/login")
+            || p.startsWith("/api/auth/refresh")
+            || p.startsWith("/error");
     }
 }

--- a/src/main/java/com/backend/security/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/backend/security/auth/jwt/JwtTokenProvider.java
@@ -151,7 +151,7 @@ public class JwtTokenProvider {
     public Authentication getAuthentication(String token) {
         Claims body = parser().parseClaimsJws(token).getBody();
         // subject = memberId 로 발급하고 있으니 Long으로 변환
-        Long memberId = Long.parseLong(body.getSubject());
+        String userId = body.getSubject();
         String role = body.get("role", String.class);
 
         List<GrantedAuthority> auths = (role != null)
@@ -162,7 +162,7 @@ public class JwtTokenProvider {
         String email = body.get("email", String.class);
 
         CustomUserPrincipal principal = CustomUserPrincipal.builder()
-                .memberId(memberId)
+                .userId(userId)
                 .email(email)
                 .authorities(auths)
                 .build();

--- a/src/main/java/com/backend/security/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/backend/security/auth/jwt/JwtTokenProvider.java
@@ -7,16 +7,21 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
+import com.backend.security.auth.user.CustomUserPrincipal;
+import org.springframework.security.core.GrantedAuthority;
 
 import java.security.Key;
 import java.util.Date;
 import java.time.Duration;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
+import java.util.Optional;
 
 @Component
 public class JwtTokenProvider {
 
+    private static final String CLAIM_TOKEN_TYPE = "token_type";
     private final Key key;
     private final long accessValidityMs;
     private final long refreshValidityMs;
@@ -55,6 +60,8 @@ public class JwtTokenProvider {
         Date exp = new Date(now.getTime() + validity);
 
         JwtBuilder builder = Jwts.builder()
+                // jti 부여
+                .setId(UUID.randomUUID().toString())
                 .setSubject(subject)
                 .setIssuedAt(now)
                 .setExpiration(exp)
@@ -64,29 +71,67 @@ public class JwtTokenProvider {
                 .setAudience(audience)
                 // 토큰 종류 구분(access, refresh)
                 .claim("typ", type)
+                .claim(CLAIM_TOKEN_TYPE, type)
                 .signWith(key, SignatureAlgorithm.HS256);
 
         if (role != null) builder.claim("role", role);
         return builder.compact();
     }
 
+    // === 파서 & 클레임 헬퍼 ===
+    private JwtParser parser() {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .setAllowedClockSkewSeconds(clockSkewSec)
+                .build();
+    }
+
+    public Claims parseClaims(String token) {
+        return parser().parseClaimsJws(token).getBody();
+    }
+
+    public Optional<String> tryGetJti(String token) {
+        try { return Optional.ofNullable(parseClaims(token).getId()); }
+        catch (Exception e) { return Optional.empty(); }
+    }
+
+    public Date getExpiresAt(String token) {
+        return parseClaims(token).getExpiration();
+    }
+
+    public long getExpiresInSeconds(String token) {
+        Date exp = getExpiresAt(token);
+        return Math.max(0, (exp.getTime() - System.currentTimeMillis()) / 1000);
+    }
+
+    public String getSubject(String token) {
+        return parseClaims(token).getSubject();
+    }
+
     // === 검증 ===
-    public JwtValidationResult validateAndWhy(String token, Set<String> acceptedAudiences) {
+    public JwtValidationResult validateAndClassify(String token) {
+        return validateAndClassify(token, Set.of(audience));
+    }
+
+    public JwtValidationResult validateAndClassify(String token, Set<String> acceptedAudiences) {
         try {
             Jws<Claims> jws = parser().parseClaimsJws(token);
             Claims c = jws.getBody();
 
-            // issuer 검증
-            if (!issuer.equals(c.getIssuer()))
+            // issuer
+            if (!issuer.equals(c.getIssuer())) {
                 return JwtValidationResult.INVALID_ISSUER;
+            }
 
-            // audience 검증
+            // audience
             if (acceptedAudiences != null && !acceptedAudiences.isEmpty()) {
-                if (c.getAudience() == null || !acceptedAudiences.contains(c.getAudience()))
+                if (c.getAudience() == null || !acceptedAudiences.contains(c.getAudience())) {
                     return JwtValidationResult.INVALID_AUDIENCE;
+                }
             } else {
-                if (!audience.equals(c.getAudience()))
+                if (!audience.equals(c.getAudience())) {
                     return JwtValidationResult.INVALID_AUDIENCE;
+                }
             }
 
             return JwtValidationResult.OK;
@@ -100,24 +145,30 @@ public class JwtTokenProvider {
     }
 
     public boolean validate(String token) {
-        return validateAndWhy(token, Set.of(audience)) == JwtValidationResult.OK;
+        return validateAndClassify(token, Set.of(audience)) == JwtValidationResult.OK;
     }
 
     public Authentication getAuthentication(String token) {
         Claims body = parser().parseClaimsJws(token).getBody();
-        String userId = body.getSubject();
+        // subject = memberId 로 발급하고 있으니 Long으로 변환
+        Long memberId = Long.parseLong(body.getSubject());
         String role = body.get("role", String.class);
-        var auth = (role != null)
-                ? new SimpleGrantedAuthority("ROLE_" + role)
-                : null;
-        return new UsernamePasswordAuthenticationToken(userId, token, auth == null ? List.of() : List.of(auth));
-    }
 
-    private JwtParser parser() {
-        return Jwts.parserBuilder()
-                .setSigningKey(key)
-                .setAllowedClockSkewSeconds(clockSkewSec)
+        List<GrantedAuthority> auths = (role != null)
+                ? List.of(new SimpleGrantedAuthority("ROLE_" + role))
+                : List.of();
+
+        // 이메일을 토큰에 안 넣었다면 null 가능. (원하면 access 토큰에 claim("email", m.getEmail()) 추가)
+        String email = body.get("email", String.class);
+
+        CustomUserPrincipal principal = CustomUserPrincipal.builder()
+                .memberId(memberId)
+                .email(email)
+                .authorities(auths)
                 .build();
+
+        // principal을 CustomUserPrincipal로!
+        return new UsernamePasswordAuthenticationToken(principal, token, auths);
     }
 
     public Duration getAccessValidity() {
@@ -126,5 +177,15 @@ public class JwtTokenProvider {
 
     public Duration getRefreshValidity() {
         return Duration.ofMillis(refreshValidityMs);
+    }
+
+    public boolean isAccessToken(String token) {
+        String typ = parseClaims(token).get(CLAIM_TOKEN_TYPE, String.class);
+        return "access".equals(typ);
+    }
+
+    public boolean isRefreshToken(String token) {
+        String typ = parseClaims(token).get(CLAIM_TOKEN_TYPE, String.class);
+        return "refresh".equals(typ);
     }
 }

--- a/src/main/java/com/backend/security/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/backend/security/auth/jwt/JwtTokenProvider.java
@@ -10,7 +10,9 @@ import org.springframework.stereotype.Component;
 
 import java.security.Key;
 import java.util.Date;
+import java.time.Duration;
 import java.util.List;
+import java.util.Set;
 
 @Component
 public class JwtTokenProvider {
@@ -18,27 +20,37 @@ public class JwtTokenProvider {
     private final Key key;
     private final long accessValidityMs;
     private final long refreshValidityMs;
+    private final String issuer;
+    private final String audience;
+    // 서버간 시각 차이로 인한 오류 방지
+    private final long clockSkewSec;
 
     public JwtTokenProvider(
             @Value("${app.jwt.secret}") String secret,
             @Value("${app.jwt.access-token-validity-ms}") long accessValidityMs,
-            @Value("${app.jwt.refresh-token-validity-ms}") long refreshValidityMs
+            @Value("${app.jwt.refresh-token-validity-ms}") long refreshValidityMs,
+            @Value("${app.jwt.issuer:my-api}") String issuer,
+            @Value("${app.jwt.audience:web}") String audience,
+            @Value("${app.jwt.clock-skew-sec:60}") long clockSkewSec
     ) {
         this.key = Keys.hmacShaKeyFor(secret.getBytes(java.nio.charset.StandardCharsets.UTF_8));
         this.accessValidityMs = accessValidityMs;
         this.refreshValidityMs = refreshValidityMs;
+        this.issuer = issuer;
+        this.audience = audience;
+        this.clockSkewSec = clockSkewSec;
     }
 
+    // === 토큰 생성 ===
     public String createAccessToken(String userId, String role) {
-        return buildToken(userId, role, accessValidityMs);
+        return buildToken(userId, role, accessValidityMs, "access");
     }
 
     public String createRefreshToken(String userId) {
-        // 리프레시는 최소 정보만 (role 불필요)
-        return buildToken(userId, null, refreshValidityMs);
+        return buildToken(userId, null, refreshValidityMs, "refresh");
     }
 
-    private String buildToken(String subject, String role, long validity) {
+    private String buildToken(String subject, String role, long validity, String type) {
         Date now = new Date();
         Date exp = new Date(now.getTime() + validity);
 
@@ -46,31 +58,73 @@ public class JwtTokenProvider {
                 .setSubject(subject)
                 .setIssuedAt(now)
                 .setExpiration(exp)
+                // 이 토큰을 누가 발급했는지(우리 서비스에서 발급한 것인가)
+                .setIssuer(issuer)
+                // 이 토큰을 누가 사용할 수 있는지(어떤 클라이언트를 위한 것인가)
+                .setAudience(audience)
+                // 토큰 종류 구분(access, refresh)
+                .claim("typ", type)
                 .signWith(key, SignatureAlgorithm.HS256);
 
         if (role != null) builder.claim("role", role);
         return builder.compact();
     }
 
-    public boolean validate(String token) {
+    // === 검증 ===
+    public JwtValidationResult validateAndWhy(String token, Set<String> acceptedAudiences) {
         try {
-            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
-            return true;
-        } catch (JwtException | IllegalArgumentException e) {
-            return false;
+            Jws<Claims> jws = parser().parseClaimsJws(token);
+            Claims c = jws.getBody();
+
+            // issuer 검증
+            if (!issuer.equals(c.getIssuer()))
+                return JwtValidationResult.INVALID_ISSUER;
+
+            // audience 검증
+            if (acceptedAudiences != null && !acceptedAudiences.isEmpty()) {
+                if (c.getAudience() == null || !acceptedAudiences.contains(c.getAudience()))
+                    return JwtValidationResult.INVALID_AUDIENCE;
+            } else {
+                if (!audience.equals(c.getAudience()))
+                    return JwtValidationResult.INVALID_AUDIENCE;
+            }
+
+            return JwtValidationResult.OK;
+        } catch (ExpiredJwtException e) { // 유효기간이 지났는지
+            return JwtValidationResult.EXPIRED;
+        } catch (io.jsonwebtoken.security.SecurityException e) { // 토큰이 서버의 비밀키로 서명된 것인지
+            return JwtValidationResult.INVALID_SIGNATURE;
+        } catch (JwtException | IllegalArgumentException e) { // JWT 구조가 올바른지
+            return JwtValidationResult.MALFORMED;
         }
     }
 
+    public boolean validate(String token) {
+        return validateAndWhy(token, Set.of(audience)) == JwtValidationResult.OK;
+    }
+
     public Authentication getAuthentication(String token) {
-        Claims body = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+        Claims body = parser().parseClaimsJws(token).getBody();
         String userId = body.getSubject();
-        String role = body.get("role", String.class); // access 토큰에는 존재
+        String role = body.get("role", String.class);
         var auth = (role != null)
                 ? new SimpleGrantedAuthority("ROLE_" + role)
                 : null;
         return new UsernamePasswordAuthenticationToken(userId, token, auth == null ? List.of() : List.of(auth));
     }
 
-    public long getAccessValidityMs()  { return accessValidityMs; }
-    public long getRefreshValidityMs() { return refreshValidityMs; }
+    private JwtParser parser() {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .setAllowedClockSkewSeconds(clockSkewSec)
+                .build();
+    }
+
+    public Duration getAccessValidity() {
+        return Duration.ofMillis(accessValidityMs);
+    }
+
+    public Duration getRefreshValidity() {
+        return Duration.ofMillis(refreshValidityMs);
+    }
 }

--- a/src/main/java/com/backend/security/auth/jwt/JwtValidationResult.java
+++ b/src/main/java/com/backend/security/auth/jwt/JwtValidationResult.java
@@ -1,0 +1,12 @@
+package com.backend.security.auth.jwt;
+
+// JWT 인증 과정이 왜 실패했는지 이유를 구체화
+public enum JwtValidationResult {
+    OK,
+    EXPIRED,
+    MALFORMED,
+    INVALID_SIGNATURE,
+    INVALID_ISSUER,
+    INVALID_AUDIENCE,
+    BLACKLISTED
+}

--- a/src/main/java/com/backend/security/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/backend/security/auth/repository/RefreshTokenRepository.java
@@ -2,14 +2,12 @@ package com.backend.security.auth.repository;
 
 import com.backend.security.auth.domain.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.transaction.annotation.Transactional;
 import java.util.Optional;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
-    Optional<RefreshToken> findByEmail(String email);
-    Optional<RefreshToken> findByToken(String token);
-    
-    @Modifying
-    @Transactional
-    void deleteByEmail(String email);
+    Optional<RefreshToken> findByTokenHash(String tokenHash);
+    Optional<RefreshToken> findByMemberId(Long memberId);
+
+    @org.springframework.transaction.annotation.Transactional
+    @org.springframework.data.jpa.repository.Modifying(clearAutomatically = true, flushAutomatically = true)
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/backend/security/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/backend/security/auth/repository/RefreshTokenRepository.java
@@ -2,12 +2,16 @@ package com.backend.security.auth.repository;
 
 import com.backend.security.auth.domain.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.transaction.annotation.Transactional;
 import java.util.Optional;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
     Optional<RefreshToken> findByTokenHash(String tokenHash);
-    Optional<RefreshToken> findByMemberId(Long memberId);
+    Optional<RefreshToken> findByUserId(String userId);
 
-    @org.springframework.transaction.annotation.Transactional
-    @org.springframework.data.jpa.repository.Modifying(clearAutomatically = true, flushAutomatically = true)
-    void deleteByMemberId(Long memberId);
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Transactional
+    @Query("delete from RefreshToken r where r.userId = :userId")   
+    int deleteByUserId(String userId);
 }

--- a/src/main/java/com/backend/security/auth/service/AuthTokenService.java
+++ b/src/main/java/com/backend/security/auth/service/AuthTokenService.java
@@ -15,7 +15,6 @@ public class AuthTokenService {
 
     private final JwtTokenProvider tokenProvider;
     private final RefreshTokenRepository refreshRepo;
-    private static final long MS_TO_SECONDS = 1000L;
 
     public AuthTokenService(JwtTokenProvider tokenProvider,
                             RefreshTokenRepository refreshRepo) {
@@ -35,7 +34,7 @@ public class AuthTokenService {
         String refresh = tokenProvider.createRefreshToken(String.valueOf(member.getId()));
 
         // 2) 만료시각 계산
-        Instant refreshExp = Instant.now().plusMillis(tokenProvider.getRefreshValidityMs());
+        Instant refreshExp = Instant.now().plus(tokenProvider.getRefreshValidity());
 
         // 3) refresh 토큰 DB 반영 (있으면 rotate, 없으면 insert)
         refreshRepo.findByEmail(member.getEmail())
@@ -52,8 +51,8 @@ public class AuthTokenService {
                 access,
                 refresh,
                 "Bearer",
-                tokenProvider.getAccessValidityMs() / MS_TO_SECONDS,
-                tokenProvider.getRefreshValidityMs() / MS_TO_SECONDS
+                tokenProvider.getAccessValidity().getSeconds(),
+                tokenProvider.getRefreshValidity().getSeconds()
         );
     }
 }

--- a/src/main/java/com/backend/security/auth/service/AuthTokenService.java
+++ b/src/main/java/com/backend/security/auth/service/AuthTokenService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 
 import com.backend.member.domain.Member;
 import com.backend.security.auth.domain.RefreshToken;
+import com.backend.security.util.HashUtil;
 import com.backend.security.auth.dto.TokenResponseDTO;
 import com.backend.security.auth.jwt.JwtTokenProvider;
 import com.backend.security.auth.repository.RefreshTokenRepository;
@@ -15,7 +16,7 @@ public class AuthTokenService {
 
     private final JwtTokenProvider tokenProvider;
     private final RefreshTokenRepository refreshRepo;
-
+    
     public AuthTokenService(JwtTokenProvider tokenProvider,
                             RefreshTokenRepository refreshRepo) {
         this.tokenProvider = tokenProvider;
@@ -29,30 +30,42 @@ public class AuthTokenService {
      */
     public TokenResponseDTO issueTokensFor(Member member) {
 
-        // 1) 새 토큰 발급
+        // 1️⃣ Access / Refresh 토큰 생성
         String access  = tokenProvider.createAccessToken(String.valueOf(member.getId()), member.getRole().name());
         String refresh = tokenProvider.createRefreshToken(String.valueOf(member.getId()));
 
-        // 2) 만료시각 계산
+        // 2️⃣ Refresh 토큰 해시 계산
+        String refreshHash = HashUtil.sha256Base64(refresh);
+        System.out.println("[LOGIN] memberId=" + member.getId()
+        + " refreshHash=" + refreshHash.substring(0, 12) + "...");
+
+
+
+        /// 3️⃣ 만료 시각 계산
         Instant refreshExp = Instant.now().plus(tokenProvider.getRefreshValidity());
 
-        // 3) refresh 토큰 DB 반영 (있으면 rotate, 없으면 insert)
-        refreshRepo.findByEmail(member.getEmail())
-                .ifPresentOrElse(
-                        rt -> {
-                            rt.rotate(refresh, refreshExp);
-                            refreshRepo.save(rt);
-                        },
-                        () -> refreshRepo.save(new RefreshToken(member.getEmail(), refresh, refreshExp))
-                );
+        // 4️⃣ DB에 저장 (있으면 rotate, 없으면 새로 생성)
+        Long memberId = Long.valueOf(member.getId());
+        refreshRepo.findByMemberId(memberId)
+        .ifPresentOrElse(
+                rt -> {
+                    System.out.println("[LOGIN] rotate existing RT row, id=" + rt.getId());
+                    rt.rotate(refreshHash, refreshExp);
+                    refreshRepo.save(rt);
+                },
+                () -> {
+                    System.out.println("[LOGIN] insert new RT row");
+                    refreshRepo.save(new RefreshToken(memberId, refreshHash, refreshExp));
+                }
+            );
 
-        // 4) 응답 DTO로 만들어 반환
-        return new TokenResponseDTO(
-                access,
-                refresh,
-                "Bearer",
-                tokenProvider.getAccessValidity().getSeconds(),
-                tokenProvider.getRefreshValidity().getSeconds()
-        );
+    // 5️⃣ 응답 DTO 리턴 (클라엔트엔 원문 refresh 전달)
+    return new TokenResponseDTO(
+        access,
+        refresh,
+        "Bearer",
+        tokenProvider.getAccessValidity().toSeconds(),
+        tokenProvider.getRefreshValidity().toSeconds()
+    );
     }
 }

--- a/src/main/java/com/backend/security/auth/service/AuthTokenService.java
+++ b/src/main/java/com/backend/security/auth/service/AuthTokenService.java
@@ -10,6 +10,8 @@ import com.backend.security.util.HashUtil;
 import com.backend.security.auth.dto.TokenResponseDTO;
 import com.backend.security.auth.jwt.JwtTokenProvider;
 import com.backend.security.auth.repository.RefreshTokenRepository;
+import org.springframework.transaction.annotation.Transactional;
+
 
 @Service
 public class AuthTokenService {
@@ -28,25 +30,26 @@ public class AuthTokenService {
      * refresh 토큰을 DB에 upsert/rotate 한 다음
      * 클라이언트에게 내려줄 TokenResponseDTO로 변환해 돌려준다.
      */
+    @Transactional
     public TokenResponseDTO issueTokensFor(Member member) {
 
+        final String userId = member.getUserId();
+
         // 1️⃣ Access / Refresh 토큰 생성
-        String access  = tokenProvider.createAccessToken(String.valueOf(member.getId()), member.getRole().name());
-        String refresh = tokenProvider.createRefreshToken(String.valueOf(member.getId()));
+        String access  = tokenProvider.createAccessToken(userId, member.getRole().name());
+        String refresh = tokenProvider.createRefreshToken(userId);
 
         // 2️⃣ Refresh 토큰 해시 계산
         String refreshHash = HashUtil.sha256Base64(refresh);
-        System.out.println("[LOGIN] memberId=" + member.getId()
-        + " refreshHash=" + refreshHash.substring(0, 12) + "...");
 
-
+        System.out.println("[LOGIN] userId=" + userId
+                + " refreshHash=" + refreshHash.substring(0, 12) + "...");
 
         /// 3️⃣ 만료 시각 계산
         Instant refreshExp = Instant.now().plus(tokenProvider.getRefreshValidity());
 
         // 4️⃣ DB에 저장 (있으면 rotate, 없으면 새로 생성)
-        Long memberId = Long.valueOf(member.getId());
-        refreshRepo.findByMemberId(memberId)
+        refreshRepo.findByUserId(userId)
         .ifPresentOrElse(
                 rt -> {
                     System.out.println("[LOGIN] rotate existing RT row, id=" + rt.getId());
@@ -55,7 +58,7 @@ public class AuthTokenService {
                 },
                 () -> {
                     System.out.println("[LOGIN] insert new RT row");
-                    refreshRepo.save(new RefreshToken(memberId, refreshHash, refreshExp));
+                    refreshRepo.save(new RefreshToken(userId, refreshHash, refreshExp));
                 }
             );
 

--- a/src/main/java/com/backend/security/auth/user/CustomUserPrincipal.java
+++ b/src/main/java/com/backend/security/auth/user/CustomUserPrincipal.java
@@ -4,8 +4,9 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
+import lombok.Builder;
 
-
+@Builder
 public class CustomUserPrincipal implements UserDetails {
 
     private final Long memberId;

--- a/src/main/java/com/backend/security/auth/user/CustomUserPrincipal.java
+++ b/src/main/java/com/backend/security/auth/user/CustomUserPrincipal.java
@@ -9,20 +9,20 @@ import lombok.Builder;
 @Builder
 public class CustomUserPrincipal implements UserDetails {
 
-    private final Long memberId;
+    private final String userId;
     private final String email;
     private final Collection<? extends GrantedAuthority> authorities;
 
-    public CustomUserPrincipal(Long memberId,
+    public CustomUserPrincipal(String userId,
                                String email,
                                Collection<? extends GrantedAuthority> authorities) {
-        this.memberId = memberId;
+        this.userId = userId;
         this.email = email;
         this.authorities = authorities;
     }
 
-    public Long getMemberId() {
-        return memberId;
+    public String getUserId() {
+        return userId;
     }
 
     public String getEmail() {

--- a/src/main/java/com/backend/security/config/SecurityConfig.java
+++ b/src/main/java/com/backend/security/config/SecurityConfig.java
@@ -33,6 +33,8 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.POST, "/api/members").permitAll() // 회원가입 공개
                 .requestMatchers("/api/auth/**").permitAll()
                 .requestMatchers("/error").permitAll()
+                .requestMatchers("/api/auth/oauth/kakao/**").permitAll()
+                .requestMatchers("/page", "/callback", "/api/auth/oauth/kakao/callback").permitAll()
                 .requestMatchers("/api/admin/**").hasRole("ADMIN")             // 관리자 전용
                 .anyRequest().authenticated()
             )

--- a/src/main/java/com/backend/security/config/SecurityConfig.java
+++ b/src/main/java/com/backend/security/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.backend.security.config;
 
+import com.backend.security.auth.blacklist.TokenBlacklistService;
 import com.backend.security.auth.jwt.JwtAuthenticationFilter;
 import com.backend.security.auth.jwt.JwtTokenProvider;
 
@@ -10,9 +11,9 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
@@ -20,6 +21,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtTokenProvider tokenProvider;
+    private final TokenBlacklistService blacklist;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -29,7 +31,8 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/healthz", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                 .requestMatchers(HttpMethod.POST, "/api/members").permitAll() // 회원가입 공개
-                .requestMatchers("/api/auth/**").permitAll()                   // 로그인 공개
+                .requestMatchers("/api/auth/**").permitAll()
+                .requestMatchers("/error").permitAll()
                 .requestMatchers("/api/admin/**").hasRole("ADMIN")             // 관리자 전용
                 .anyRequest().authenticated()
             )
@@ -37,9 +40,16 @@ public class SecurityConfig {
             .formLogin(f -> f.disable())
             .logout(Customizer.withDefaults());
 
-        http.addFilterBefore(new JwtAuthenticationFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class);
+        // JWT 필터 등록 (블랙리스트 주입, 필요 시 audience도 전달 가능)
+        http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 
-    @Bean public PasswordEncoder passwordEncoder() { return new BCryptPasswordEncoder(); }
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(tokenProvider, blacklist);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() { return new BCryptPasswordEncoder(); }
 }

--- a/src/main/java/com/backend/security/oauth/kakao/KakaoOAuthClient.java
+++ b/src/main/java/com/backend/security/oauth/kakao/KakaoOAuthClient.java
@@ -1,0 +1,51 @@
+package com.backend.security.oauth.kakao;
+
+import com.backend.security.oauth.kakao.dto.KakaoTokenResponseDTO;
+import com.backend.security.oauth.kakao.dto.KakaoUserResponseDTO;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class KakaoOAuthClient {
+
+    private final WebClient webClient = WebClient.builder().build();
+    private final KakaoOAuthProperties props;
+
+    public KakaoOAuthClient(KakaoOAuthProperties props) {
+        this.props = props;
+    }
+
+    // 1) 인가코드 → 카카오 액세스 토큰
+    public KakaoTokenResponseDTO exchangeCodeForToken(String code) {
+        String body = "grant_type=authorization_code" +
+                "&client_id=" + enc(props.getClientId()) +
+                (isBlank(props.getClientSecret()) ? "" : "&client_secret=" + enc(props.getClientSecret())) +
+                "&redirect_uri=" + enc(props.getRedirectUri()) +
+                "&code=" + enc(code);
+
+        return webClient.post()
+                .uri("https://kauth.kakao.com/oauth/token")
+                .header("Content-Type", MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(KakaoTokenResponseDTO.class)
+                .block();
+    }
+
+    // 2) 카카오 액세스 토큰 → 사용자 정보
+    public KakaoUserResponseDTO fetchUser(String kakaoAccessToken) {
+        return webClient.get()
+                .uri("https://kapi.kakao.com/v2/user/me")
+                .header("Authorization", "Bearer " + kakaoAccessToken)
+                .retrieve()
+                .bodyToMono(KakaoUserResponseDTO.class)
+                .block();
+    }
+
+    private static boolean isBlank(String s) { return s == null || s.isBlank(); }
+    private static String enc(String s) { return URLEncoder.encode(s, StandardCharsets.UTF_8); }
+}

--- a/src/main/java/com/backend/security/oauth/kakao/KakaoOAuthProperties.java
+++ b/src/main/java/com/backend/security/oauth/kakao/KakaoOAuthProperties.java
@@ -1,0 +1,16 @@
+package com.backend.security.oauth.kakao;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import lombok.Getter;
+import lombok.Setter;
+
+@Component
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "app.oauth.kakao")
+public class KakaoOAuthProperties {
+    private String clientId;
+    private String clientSecret;
+    private String redirectUri;
+}

--- a/src/main/java/com/backend/security/oauth/kakao/dto/KakaoAccessTokenLoginRequestDTO.java
+++ b/src/main/java/com/backend/security/oauth/kakao/dto/KakaoAccessTokenLoginRequestDTO.java
@@ -1,0 +1,8 @@
+package com.backend.security.oauth.kakao.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+// 모바일/프론트 SDK가 준 카카오 access_token을 직접 받는 경우(대체 루트)
+public record KakaoAccessTokenLoginRequestDTO(
+        @NotBlank String kakaoAccessToken
+) {}

--- a/src/main/java/com/backend/security/oauth/kakao/dto/KakaoLoginRequestDTO.java
+++ b/src/main/java/com/backend/security/oauth/kakao/dto/KakaoLoginRequestDTO.java
@@ -1,0 +1,8 @@
+package com.backend.security.oauth.kakao.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+// 클라이언트로부터 받는 인가코드 DTO
+public record KakaoLoginRequestDTO(
+        @NotBlank String code
+) {}

--- a/src/main/java/com/backend/security/oauth/kakao/dto/KakaoTokenResponseDTO.java
+++ b/src/main/java/com/backend/security/oauth/kakao/dto/KakaoTokenResponseDTO.java
@@ -1,0 +1,11 @@
+package com.backend.security.oauth.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoTokenResponseDTO(
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("token_type") String tokenType,
+        @JsonProperty("refresh_token") String refreshToken,
+        @JsonProperty("expires_in") Long expiresIn,
+        @JsonProperty("scope") String scope
+) {}

--- a/src/main/java/com/backend/security/oauth/kakao/dto/KakaoUserResponseDTO.java
+++ b/src/main/java/com/backend/security/oauth/kakao/dto/KakaoUserResponseDTO.java
@@ -1,0 +1,18 @@
+package com.backend.security.oauth.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoUserResponseDTO(
+        Long id,
+        @JsonProperty("kakao_account") KakaoAccount kakaoAccount
+) {
+    public record KakaoAccount(
+            String email,
+            Profile profile
+    ) {
+        public record Profile(
+                String nickname,
+                @JsonProperty("profile_image_url") String profileImageUrl
+        ){}
+    }
+}

--- a/src/main/java/com/backend/security/util/HashUtil.java
+++ b/src/main/java/com/backend/security/util/HashUtil.java
@@ -1,0 +1,19 @@
+package com.backend.security.util;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Base64;
+
+public final class HashUtil {
+    private HashUtil() {}
+
+    public static String sha256Base64(String input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] hashBytes = md.digest(input.getBytes(StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(hashBytes);
+        } catch (Exception e) {
+            throw new IllegalStateException("Hash error", e);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,9 @@ springdoc:
 
 app:
   jwt:
-    access-token-validity-ms: 3600000
+    secret: ${JWT_SECRET:local-secret-key}
+    issuer: my-backend-api
+    audience: web
+    access-token-validity-ms: 900000
     refresh-token-validity-ms: 1209600000
-    secret: VlwEyVBsYt9V7zq57TejMnVUyzblYcfPQye08f7MGVA9XkHa #임시 64bytes random secret. 실제 배포 환경에서는 .env에 설정할 것.
+    clock-skew-sec: 60

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,10 @@ server:
 spring:
   application:
     name: be-api
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
 
 springdoc:
   swagger-ui:
@@ -13,9 +17,13 @@ springdoc:
 
 app:
   jwt:
-    secret: ${JWT_SECRET:local-secret-key}
+    secret: "WlV5b1p3ZjlxQmJvRzZyOXpZK0FteS1wSFh3czZfV2h5Zk1wbUhYd2s5S0pU"
     issuer: my-backend-api
     audience: web
     access-token-validity-ms: 900000
     refresh-token-validity-ms: 1209600000
     clock-skew-sec: 60
+
+logging:
+  level:
+    org.springframework.security: DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,8 @@ spring:
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
+  thymeleaf:
+    cache: false
 
 springdoc:
   swagger-ui:
@@ -23,6 +25,12 @@ app:
     access-token-validity-ms: 900000
     refresh-token-validity-ms: 1209600000
     clock-skew-sec: 60
+  oauth:
+    kakao:
+      client-id: ${KAKAO_REST_API_KEY}
+      redirect-uri: ${KAKAO_REDIRECT_URI}
+      client-secret: ""
+      admin-key: ""
 
 logging:
   level:

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>KakaoLogin</title>
+</head>
+<body>
+<div class="container" style="display: flex; justify-content: center; align-content: center; align-items: center; flex-direction: column; margin: 200px auto; ">
+    <h1>카카오 로그인</h1>
+    <a th:href="${location}">
+        <img src="/kakao_login_medium_narrow.png" >
+    </a>
+</div>
+</body>
+</html>


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #10 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
- 카카오 소셜 로그인 임시 프론트 페이지(`/page`) 구현  
  → Thymeleaf 템플릿으로 Kakao 인증 버튼 표시  
- `.env` 기반 환경변수 적용 (`KAKAO_REST_API_KEY`, `KAKAO_REDIRECT_URI`)  
  → `spring-dotenv` 라이브러리 사용  
- `application.yml` 내 카카오 OAuth 설정 수정  
  → `${KAKAO_REST_API_KEY}`, `${KAKAO_REDIRECT_URI}` 로 매핑  
- Kakao 로그인 Redirect URI 검증 및 KOE101 오류 해결  

## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
