### PR TITLE
[REFACTOR] MemberController의 DTO 변환 로직을 Service 계층으로 이동

### DIFF
--- a/src/main/java/com/backend/member/controller/MemberController.java
+++ b/src/main/java/com/backend/member/controller/MemberController.java
@@ -15,11 +15,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-
-import com.backend.member.domain.Member;
 import com.backend.member.dto.LocalSignUpRequestDTO;
-import com.backend.member.dto.UpdateNicknameRequestDTO;
 import com.backend.member.dto.MemberResponseDTO;
+import com.backend.member.dto.UpdateNicknameRequestDTO;
 import com.backend.member.service.MemberService;
 import com.backend.security.auth.user.CustomUserPrincipal;
 
@@ -35,52 +33,40 @@ public class MemberController {
     @Operation(summary = "회원 가입")
     @PostMapping
     public ResponseEntity<MemberResponseDTO> signUp(@Valid @RequestBody LocalSignUpRequestDTO req) {
-        Member saved = memberService.signUp(req);
-        return ResponseEntity.ok(MemberResponseDTO.from(saved));
+        return ResponseEntity.ok(memberService.signUp(req));
     }
 
     @Operation(summary = "회원 단일 조회")
-    @GetMapping("/{id}")
-    public ResponseEntity<MemberResponseDTO> get(@PathVariable String userId) {
-        Member found = memberService.getByUserId(userId);
-        return ResponseEntity.ok(MemberResponseDTO.from(found));
+    @GetMapping("/{user_id}")
+    public ResponseEntity<MemberResponseDTO> getByUserId(@PathVariable String userId) {
+        return ResponseEntity.ok(memberService.getByUserId(userId));
     }
 
     @Operation(summary = "회원 목록 조회 (페이지)")
     @GetMapping
     public ResponseEntity<Page<MemberResponseDTO>> list(Pageable pageable) {
-        Page<MemberResponseDTO> page = memberService
-                .list(pageable)
-                .map(MemberResponseDTO::from);
-        return ResponseEntity.ok(page);
+        return ResponseEntity.ok(memberService.list(pageable));
     }
 
     @Operation(summary = "내 닉네임 변경")
     @PatchMapping("/me/nickname")
     public ResponseEntity<MemberResponseDTO> changeMyNickname(
-        @AuthenticationPrincipal CustomUserPrincipal me,
-        @Valid @RequestBody UpdateNicknameRequestDTO req
+            @AuthenticationPrincipal CustomUserPrincipal me,
+            @Valid @RequestBody UpdateNicknameRequestDTO req
     ) {
-        String myUserId = me.getUserId();
-        Member updated = memberService.changeNicknameByUserId(myUserId, req);
-        return ResponseEntity.ok(MemberResponseDTO.from(updated));
+        return ResponseEntity.ok(memberService.changeNicknameByUserId(me.getUserId(), req));
     }
     
     @Operation(summary = "본인 회원 탈퇴")
     @DeleteMapping("/me")
-    public ResponseEntity<Void> deleteMe(
-        @AuthenticationPrincipal CustomUserPrincipal me
-    ) {
-        String myUserId = me.getUserId();
-        memberService.deleteByUserId(myUserId);
+    public ResponseEntity<Void> deleteMe(@AuthenticationPrincipal CustomUserPrincipal me) {
+        memberService.deleteByUserId(me.getUserId());
         return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "내 정보 조회")
     @GetMapping("/me")
     public ResponseEntity<MemberResponseDTO> getMe(@AuthenticationPrincipal CustomUserPrincipal me) {
-        if (me == null) return ResponseEntity.status(401).build();
-        Member found = memberService.getByUserId(me.getUserId());
-        return ResponseEntity.ok(MemberResponseDTO.from(found));
+        return ResponseEntity.ok(memberService.getByUserId(me.getUserId()));
     }
 }

--- a/src/main/java/com/backend/member/service/MemberService.java
+++ b/src/main/java/com/backend/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.backend.member.service;
 import com.backend.member.domain.Member;
 import com.backend.member.domain.Role;
 import com.backend.member.dto.LocalSignUpRequestDTO;
+import com.backend.member.dto.MemberResponseDTO;
 import com.backend.member.dto.UpdateNicknameRequestDTO;
 import com.backend.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +25,7 @@ public class MemberService {
      * 로컬 회원가입
      */
     @Transactional
-    public Member signUp(LocalSignUpRequestDTO req) {
+    public MemberResponseDTO signUp(LocalSignUpRequestDTO req) {
         if (repo.existsByEmail(req.email())) {
             throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
         }
@@ -32,51 +33,53 @@ public class MemberService {
         String encodedPw = encoder.encode(req.password());
 
         // UUID userId는 @PrePersist에서 자동 생성됨
-        Member member = Member.local(
+        Member saved = Member.local(
                 null,               // userId (null → 자동 UUID)
                 req.email(),
                 encodedPw,
                 req.nickname()
         );
 
-        return repo.save(member);
+        return MemberResponseDTO.from(saved);
     }
 
     /**
      * 회원 단일 조회 (readOnly 트랜잭션)
      */
-    public Member getByUserId(String userId) {
-        return repo.findByUserId(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+    public MemberResponseDTO getByUserId(String userId) {
+        Member m = repo.findByUserId(userId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+        return MemberResponseDTO.from(m);
     }
 
     /**
      * 회원 목록 조회 (페이지)
      */
-    public Page<Member> list(Pageable pageable) {
-        return repo.findAll(pageable);
+    public Page<MemberResponseDTO> list(Pageable pageable) {
+        return repo.findAll(pageable)
+                   .map(MemberResponseDTO::from);
     }
 
     /**
      * 닉네임 변경 (쓰기 작업)
      */
     @Transactional
-    public Member changeNicknameByUserId(String userId, UpdateNicknameRequestDTO req) {
+    public MemberResponseDTO changeNicknameByUserId(String userId, UpdateNicknameRequestDTO req) {
         Member m = repo.findByUserId(userId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
         m.changeNickname(req.nickname());
-        return m;
+        return MemberResponseDTO.from(m);
     }
 
     /**
      * 관리자 승격 (어드민 기능)
      */
     @Transactional
-    public Member promoteToAdmin(String userId) {
+    public MemberResponseDTO promoteToAdmin(String userId) {
         Member m = repo.findByUserId(userId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
         m.changeRole(Role.ADMIN);
-        return m;
+        return MemberResponseDTO.from(m);
     }
 
     /**


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #23 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
- Controller에서 DTO 변환(`MemberResponseDTO.from()`) 수행하던 로직을 Service 계층으로 이동
- Service가 DTO를 직접 반환하도록 구조 개선
- Controller는 입출력 관리에만 집중하도록 책임 분리
- `MemberService` 전반적으로 `MemberResponseDTO` 반환 타입으로 리팩토링

## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
