### PR TITLE
[FIX] docker 환경에서 application-docker.yml 포함되지 않는 문제

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,3 +47,4 @@ logging:
     org.springframework.security: DEBUG
     org.hibernate.SQL: debug
     org.hibernate.orm.jdbc.bind: trace
+


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #36 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
- application-docker.yml이 jar 내부에 포함되도록 application.yml에 spring.config.import 추가
- docker 환경에서 datasource 설정이 정상 로딩되도록 수정
- 로컬에서 jar 내용 확인 (jar tf build/libs/app.jar로 검증 완료)

## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
