### PR TITLE
[FEAT] 최근/인기 검색어 검색 엔진과 결합

### DIFF
--- a/src/main/java/com/backend/question/controller/QuestionController.java
+++ b/src/main/java/com/backend/question/controller/QuestionController.java
@@ -63,14 +63,12 @@ public class QuestionController {
             keyword != null &&
             !keyword.isBlank()) {
 
-            String normalized = keyword.trim();
-
             recentSearchService.addKeyword(
                     String.valueOf(me.getUserId()),
-                    normalized
+                    keyword
             );
 
-            popularSearchService.increase(normalized);
+            popularSearchService.increase(keyword);
         }
 
         Page<QuestionResponseDTO> responses =  questionService.searchQuestions(questionSearchRequestDTO, pageable);

--- a/src/main/java/com/backend/question/controller/QuestionController.java
+++ b/src/main/java/com/backend/question/controller/QuestionController.java
@@ -17,6 +17,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import com.backend.search.service.RecentSearchService;
+import com.backend.search.service.PopularSearchService;
 
 import java.util.List;
 
@@ -26,6 +28,8 @@ import java.util.List;
 public class QuestionController {
 
     private final QuestionService questionService;
+    private final RecentSearchService recentSearchService;
+    private final PopularSearchService popularSearchService;
 
     @PostMapping
     public ResponseEntity<CreateQuestionResponseDTO> createFirstQuestion(@AuthenticationPrincipal CustomUserPrincipal me, @RequestBody CreateFirstQuestionRequestDTO dto) {
@@ -48,10 +52,27 @@ public class QuestionController {
 
     @PostMapping("/search")
     public ResponseEntity<Page<QuestionResponseDTO>> searchQuestions(
+            @AuthenticationPrincipal CustomUserPrincipal me,
             @RequestBody QuestionSearchRequestDTO questionSearchRequestDTO,
             @PageableDefault(size = 20, sort = "id", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {
+        String keyword = questionSearchRequestDTO.keyword();
+
+        if (me != null &&
+            keyword != null &&
+            !keyword.isBlank()) {
+
+            String normalized = keyword.trim();
+
+            recentSearchService.addKeyword(
+                    String.valueOf(me.getUserId()),
+                    normalized
+            );
+
+            popularSearchService.increase(normalized);
+        }
+
         Page<QuestionResponseDTO> responses =  questionService.searchQuestions(questionSearchRequestDTO, pageable);
         return ResponseEntity.status(HttpStatus.OK).body(responses);
 

--- a/src/main/java/com/backend/search/scheduler/PopularSearchSnapshotScheduler.java
+++ b/src/main/java/com/backend/search/scheduler/PopularSearchSnapshotScheduler.java
@@ -17,7 +17,7 @@ public class PopularSearchSnapshotScheduler {
      * 매 정각마다 현재 인기 검색어 TOP 50 스냅샷 저장
      *  - 필요에 따라 개수 조절 가능
      */
-    @Scheduled(cron = "0 0 * * * *") // 초 분 시 일 월 요일 (여기선 매 시간 00분) <- 시간 간격 어떻게 설정할까요?
+    @Scheduled(cron = "0 0 * * * *") // 초 분 시 일 월 요일 (매 시간 00분: 1시간 간격)
     public void snapshotHourly() {
         log.info("[PopularSearch] Taking hourly snapshot...");
         popularSearchService.snapshotTopKeywords(50);

--- a/src/main/java/com/backend/security/config/SecurityConfig.java
+++ b/src/main/java/com/backend/security/config/SecurityConfig.java
@@ -42,6 +42,8 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/api/v1/questions/*/like").permitAll()
                 .requestMatchers(HttpMethod.POST, "/api/v1/questions/*/like").authenticated()
                 .requestMatchers(HttpMethod.DELETE, "/api/v1/questions/*/like").authenticated()
+                .requestMatchers("/api/v1/questions/search").permitAll()
+                .requestMatchers("/api/v1/search").permitAll()
                 .requestMatchers("/api/v1/contents/**").permitAll()
                 .requestMatchers("/api/admin/**").hasRole("ADMIN")             // 관리자 전용
                 .anyRequest().authenticated()


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #49 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
- `/api/v1/questions/search` 호출 시 최근 검색어 저장 기능 추가
- 로그인 사용자의 검색어를 Redis List에 저장하도록 구현
- 인기 검색어 ZSET에 검색 키워드 카운트 증가 기능 연동
- 검색어가 null/blank일 경우 저장·카운트 증가 로직 제외
- `QuestionController`에 `RecentSearchService`, `PopularSearchService` 의존성 주입
- 기존 인기 검색어 스냅샷 스케줄러와 전체 검색 로직 정상 동작 확인

## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
