### PR TITLE
[FEAT] 채팅 메시지 스크랩 기능 구현

### DIFF
--- a/src/main/java/com/backend/question/controller/QuestionController.java
+++ b/src/main/java/com/backend/question/controller/QuestionController.java
@@ -17,10 +17,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import com.backend.search.service.RecentSearchService;
-import com.backend.search.service.PopularSearchService;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/questions")
@@ -28,8 +24,6 @@ import java.util.List;
 public class QuestionController {
 
     private final QuestionService questionService;
-    private final RecentSearchService recentSearchService;
-    private final PopularSearchService popularSearchService;
 
     @PostMapping
     public ResponseEntity<CreateQuestionResponseDTO> createFirstQuestion(@AuthenticationPrincipal CustomUserPrincipal me, @RequestBody CreateFirstQuestionRequestDTO dto) {
@@ -57,23 +51,7 @@ public class QuestionController {
             @PageableDefault(size = 20, sort = "id", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {
-        String keyword = questionSearchRequestDTO.keyword();
-
-        if (me != null &&
-            keyword != null &&
-            !keyword.isBlank()) {
-
-            recentSearchService.addKeyword(
-                    String.valueOf(me.getUserId()),
-                    keyword
-            );
-
-            popularSearchService.increase(keyword);
-        }
-
         Page<QuestionResponseDTO> responses =  questionService.searchQuestions(questionSearchRequestDTO, pageable);
         return ResponseEntity.status(HttpStatus.OK).body(responses);
-
     }
-
 }

--- a/src/main/java/com/backend/scrap/controller/MessageScrapController.java
+++ b/src/main/java/com/backend/scrap/controller/MessageScrapController.java
@@ -1,0 +1,77 @@
+package com.backend.scrap.controller;
+
+import com.backend.scrap.dto.MessageScrapResponseDTO;
+import com.backend.scrap.dto.ScrapMessageDTO;
+import com.backend.scrap.service.MessageScrapService;
+import com.backend.security.auth.exception.AuthError;
+import com.backend.security.auth.user.CustomUserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Message Scrap", description = "채팅 메시지 스크랩 API")
+@RestController
+@RequestMapping("/api/v1/messages")
+@RequiredArgsConstructor
+public class MessageScrapController {
+
+    private final MessageScrapService messageScrapService;
+
+    @Operation(summary = "메시지 스크랩")
+    @PostMapping("/{messageId}/scrap")
+    public ResponseEntity<MessageScrapResponseDTO> scrap(
+            @AuthenticationPrincipal CustomUserPrincipal me,
+            @PathVariable Long messageId
+    ) {
+        if (me == null) {
+            throw new AuthError("unauthorized", "로그인이 필요합니다.");
+        }
+
+        String userId = me.getUserId();
+        MessageScrapResponseDTO dto = messageScrapService.scrap(userId, messageId);
+        return ResponseEntity.ok(dto);
+    }
+
+    @Operation(summary = "메시지 스크랩 취소")
+    @DeleteMapping("/{messageId}/scrap")
+    public ResponseEntity<MessageScrapResponseDTO> unscrap(
+            @AuthenticationPrincipal CustomUserPrincipal me,
+            @PathVariable Long messageId
+    ) {
+        if (me == null) {
+            throw new AuthError("unauthorized", "로그인이 필요합니다.");
+        }
+
+        String userId = me.getUserId();
+        MessageScrapResponseDTO dto = messageScrapService.unscrap(userId, messageId);
+        return ResponseEntity.ok(dto);
+    }
+
+    @Operation(summary = "내 스크랩 메시지 목록 조회")
+    @GetMapping("/scrap/me")
+    public ResponseEntity<List<ScrapMessageDTO>> getMyScraps(
+            @AuthenticationPrincipal CustomUserPrincipal me
+    ) {
+        if (me == null) {
+            throw new AuthError("unauthorized", "로그인이 필요합니다.");
+        }
+
+        String userId = me.getUserId();
+        List<ScrapMessageDTO> list = messageScrapService.getMyScraps(userId);
+        return ResponseEntity.ok(list);
+    }
+
+    @Operation(summary = "특정 사용자의 스크랩 메시지 목록 조회")
+    @GetMapping("/scrap/{userId}")
+    public ResponseEntity<List<ScrapMessageDTO>> getUserScraps(
+            @PathVariable String targetUserId
+    ) {
+        List<ScrapMessageDTO> list = messageScrapService.getMyScraps(targetUserId);
+        return ResponseEntity.ok(list);
+    }
+}

--- a/src/main/java/com/backend/scrap/domain/MessageScrap.java
+++ b/src/main/java/com/backend/scrap/domain/MessageScrap.java
@@ -1,0 +1,61 @@
+package com.backend.scrap.domain;
+
+import com.backend.member.domain.Member;
+import com.backend.message.domain.Message;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Id;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Column;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "message_scraps",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_message_scrap_member_message",
+                        columnNames = {"member_id", "message_id"}
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MessageScrap {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 스크랩한 유저
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    // 스크랩 대상 메시지(댓글)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "message_id", nullable = false)
+    private Message message;
+
+    @Column(name = "scrapped_at", nullable = false)
+    private LocalDateTime scrappedAt;
+
+    private MessageScrap(Member member, Message message) {
+        this.member = member;
+        this.message = message;
+        this.scrappedAt = LocalDateTime.now();
+    }
+
+    public static MessageScrap of(Member member, Message message) {
+        return new MessageScrap(member, message);
+    }
+}

--- a/src/main/java/com/backend/scrap/dto/MessageScrapResponseDTO.java
+++ b/src/main/java/com/backend/scrap/dto/MessageScrapResponseDTO.java
@@ -1,0 +1,16 @@
+package com.backend.scrap.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * 메시지 스크랩 토글/조회 결과 DTO
+ *
+ * @param messageId  스크랩 대상 메시지 ID
+ * @param scrapped   현재 유저 기준으로 스크랩 여부
+ * @param scrappedAt 스크랩 시각(스크랩 상태가 false인 경우 null)
+ */
+public record MessageScrapResponseDTO(
+        Long messageId,
+        boolean scrapped,
+        LocalDateTime scrappedAt
+) {}

--- a/src/main/java/com/backend/scrap/dto/ScrapMessageDTO.java
+++ b/src/main/java/com/backend/scrap/dto/ScrapMessageDTO.java
@@ -1,0 +1,17 @@
+package com.backend.scrap.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * 내 스크랩 목록 조회용 DTO
+ *
+ * message 내용이나 room 정보가 필요하면
+ * Message 엔티티에서 가져다가 추가하면 됨.
+ */
+public record ScrapMessageDTO(
+        Long scrapId,
+        Long messageId,
+        Long roomId,
+        String content,
+        LocalDateTime scrappedAt
+) {}

--- a/src/main/java/com/backend/scrap/repository/MessageScrapRepository.java
+++ b/src/main/java/com/backend/scrap/repository/MessageScrapRepository.java
@@ -1,0 +1,18 @@
+package com.backend.scrap.repository;
+
+import com.backend.member.domain.Member;
+import com.backend.message.domain.Message;
+import com.backend.scrap.domain.MessageScrap;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MessageScrapRepository extends JpaRepository<MessageScrap, Long> {
+
+    boolean existsByMemberAndMessage(Member member, Message message);
+
+    Optional<MessageScrap> findByMemberAndMessage(Member member, Message message);
+
+    List<MessageScrap> findByMemberOrderByIdDesc(Member member);
+}

--- a/src/main/java/com/backend/scrap/service/MessageScrapService.java
+++ b/src/main/java/com/backend/scrap/service/MessageScrapService.java
@@ -1,0 +1,125 @@
+package com.backend.scrap.service;
+
+import com.backend.member.domain.Member;
+import com.backend.member.repository.MemberRepository;
+import com.backend.message.domain.Message;
+import com.backend.message.repository.MessageRepository;
+import com.backend.scrap.domain.MessageScrap;
+import com.backend.scrap.dto.MessageScrapResponseDTO;
+import com.backend.scrap.dto.ScrapMessageDTO;
+import com.backend.scrap.repository.MessageScrapRepository;
+import com.backend.security.auth.exception.AuthError;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MessageScrapService {
+
+    private final MessageScrapRepository messageScrapRepository;
+    private final MemberRepository memberRepository;
+    private final MessageRepository messageRepository;
+
+    /**
+     * 메시지 스크랩 추가 (이미 스크랩 상태면 그대로 유지 - idempotent)
+     */
+    public MessageScrapResponseDTO scrap(String userId, Long messageId) {
+        Member me = memberRepository.findByUserId(userId)
+                .orElseThrow(() -> new AuthError("not_found_member", "존재하지 않는 회원입니다."));
+
+        Message message = messageRepository.findById(messageId)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 메시지입니다."));
+
+        return messageScrapRepository.findByMemberAndMessage(me, message)
+                .map(scrap -> new MessageScrapResponseDTO(
+                        message.getId(),
+                        true,
+                        scrap.getScrappedAt()
+                ))
+                .orElseGet(() -> {
+                    MessageScrap saved = messageScrapRepository.save(MessageScrap.of(me, message));
+                    return new MessageScrapResponseDTO(
+                            message.getId(),
+                            true,
+                            saved.getScrappedAt()
+                    );
+                });
+    }
+
+    /**
+     * 스크랩 취소 (없어도 에러 내지 않고 조용히 처리)
+     */
+    public MessageScrapResponseDTO unscrap(String userId, Long messageId) {
+        Member me = memberRepository.findByUserId(userId)
+                .orElseThrow(() -> new AuthError("not_found_member", "존재하지 않는 회원입니다."));
+
+        Message message = messageRepository.findById(messageId)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 메시지입니다."));
+
+        messageScrapRepository.findByMemberAndMessage(me, message)
+                .ifPresent(messageScrapRepository::delete);
+
+        // scrappedAt 은 이제 의미 없으니 null
+        return new MessageScrapResponseDTO(message.getId(), false, null);
+    }
+
+    /**
+     * 내 스크랩 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public List<ScrapMessageDTO> getMyScraps(String userId) {
+        Member me = memberRepository.findByUserId(userId)
+                .orElseThrow(() -> new AuthError("not_found_member", "존재하지 않는 회원입니다."));
+
+        List<MessageScrap> scraps = messageScrapRepository.findByMemberOrderByIdDesc(me);
+
+        return scraps.stream()
+                .map(scrap -> {
+                    Message m = scrap.getMessage();
+                    Long roomId = (m.getRoom() != null) ? m.getRoom().getId() : null;
+                    String content = m.getContent(); // Message 엔티티에 맞게 필드명 조정
+                    return new ScrapMessageDTO(
+                            scrap.getId(),
+                            m.getId(),
+                            roomId,
+                            content,
+                            scrap.getScrappedAt()
+                    );
+                })
+                .toList();
+    }
+
+    /**
+    * 특정 사용자의 스크랩 목록 조회 (친구 관계 검증 포함)
+    */
+    @Transactional(readOnly = true)
+    public List<ScrapMessageDTO> getUserScraps(String targetUserId) {
+
+    // 타겟 사용자 조회
+    Member target = memberRepository.findByUserId(targetUserId)
+            .orElseThrow(() -> new AuthError("not_found_target_member", "조회 대상 사용자가 존재하지 않습니다."));
+
+    // 스크랩 조회
+    List<MessageScrap> scraps = messageScrapRepository.findByMemberOrderByIdDesc(target);
+
+    return scraps.stream()
+        .map(scrap -> {
+                Message m = scrap.getMessage();
+                Long roomId = (m.getRoom() != null) ? m.getRoom().getId() : null;
+
+                return new ScrapMessageDTO(
+                        scrap.getId(),
+                        m.getId(),
+                        roomId,
+                        m.getContent(),
+                        scrap.getScrappedAt()
+                );
+        })
+        .toList();
+    }
+}

--- a/src/main/java/com/backend/security/config/SecurityConfig.java
+++ b/src/main/java/com/backend/security/config/SecurityConfig.java
@@ -34,18 +34,37 @@ public class SecurityConfig {
             .csrf(csrf -> csrf.disable())
             .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/healthz", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                .requestMatchers(HttpMethod.POST, "/api/v1/members").permitAll() // 회원가입 공개
-                .requestMatchers("/api/v1/auth/**").permitAll()
-                .requestMatchers("/error").permitAll()
-                .requestMatchers("/page", "/callback", "/api/v1/auth/oauth/kakao/callback").permitAll()
+                // 공개 API
+                .requestMatchers(
+                    "/healthz",
+                    "/swagger-ui/**",
+                    "/v3/api-docs/**",
+                    "/error",
+                    "/page",
+                    "/callback",
+                    "/api/v1/auth/**",
+                    "/api/v1/auth/oauth/kakao/callback",
+                    "/api/v1/questions/search",
+                    "/api/v1/contents/**",
+                    "/api/v1/search/**"
+                ).permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/v1/members").permitAll()
+
+                // 질문 좋아요
                 .requestMatchers(HttpMethod.GET, "/api/v1/questions/*/like").permitAll()
                 .requestMatchers(HttpMethod.POST, "/api/v1/questions/*/like").authenticated()
                 .requestMatchers(HttpMethod.DELETE, "/api/v1/questions/*/like").authenticated()
-                .requestMatchers("/api/v1/questions/search").permitAll()
-                .requestMatchers("/api/v1/search/**").permitAll()
-                .requestMatchers("/api/v1/contents/**").permitAll()
-                .requestMatchers("/api/admin/**").hasRole("ADMIN")             // 관리자 전용
+
+                // 메시지 스크랩
+                .requestMatchers(HttpMethod.POST, "/api/v1/messages/*/scrap").authenticated()
+                .requestMatchers(HttpMethod.DELETE, "/api/v1/messages/*/scrap").authenticated()
+                .requestMatchers(HttpMethod.GET, "/api/v1/messages/scrap/me").authenticated()
+                .requestMatchers(HttpMethod.GET,    "/api/v1/messages/scrap/*").authenticated()
+
+                // 관리자 전용
+                .requestMatchers("/api/admin/**").hasRole("ADMIN")
+
+                // 나머지
                 .anyRequest().authenticated()
             )
             .httpBasic(b -> b.disable())


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #54 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
- 사용자가 특정 채팅 메시지를 스크랩(저장)할 수 있는 기능을 추가했습니다.
- 채팅 메시지 엔티티에 `scrappedBy` 혹은 별도의 Scrap 엔티티를 두고 유저별 스크랩 정보 저장.
- 스크랩/언스크랩 API 구현 (`POST /api/v1/chat/{messageId}/scrap`, `DELETE /api/v1/chat/{messageId}/scrap`)
- 스크랩된 메시지 조회 API 구현 (`GET /api/v1/chat/scraps`)
- 서비스/레포지토리 레이어 작성 및 예외 처리 추가
- JWT 인증 사용자 기준으로 동작하도록 인증 필터 연동 완료

## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
