### PR TITLE
[FEAT] 검색 엔진 구현

### DIFF
--- a/src/main/java/com/backend/content/repository/ContentRepository.java
+++ b/src/main/java/com/backend/content/repository/ContentRepository.java
@@ -1,10 +1,18 @@
 package com.backend.content.repository;
 
 import com.backend.content.domain.Content;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface ContentRepository extends JpaRepository<Content, Long> {
     Optional<Content> findByName(String name);
+
+    Page<Content> findByNameContainingIgnoreCaseOrDescriptionContainingIgnoreCase(
+            String nameKeyword,
+            String descriptionKeyword,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/backend/question/dto/QuestionSearchRepository.java
+++ b/src/main/java/com/backend/question/dto/QuestionSearchRepository.java
@@ -1,0 +1,15 @@
+package com.backend.question.dto;
+
+import com.backend.question.domain.Question;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuestionSearchRepository extends JpaRepository<Question, Long> {
+
+    Page<Question> findByTitleContainingIgnoreCaseOrDescriptionContainingIgnoreCase(
+            String title,
+            String description,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/backend/question/repository/QuestionRepository.java
+++ b/src/main/java/com/backend/question/repository/QuestionRepository.java
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
@@ -22,5 +24,10 @@ public interface QuestionRepository extends JpaRepository<Question, Long>, Quest
     @QueryHints({@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000")})
     Optional<Question> findByIdWithLock(@Param("id")Long id);
 
-
+        // ✅ 제목 또는 설명에 keyword가 포함된 질문을 검색 (대소문자 무시)
+    Page<Question> findByTitleContainingIgnoreCaseOrDescriptionContainingIgnoreCase(
+        String titleKeyword,
+        String descriptionKeyword,
+        Pageable pageable
+    );
 }

--- a/src/main/java/com/backend/question/repository/QuestionSearchRepository.java
+++ b/src/main/java/com/backend/question/repository/QuestionSearchRepository.java
@@ -1,4 +1,4 @@
-package com.backend.question.dto;
+package com.backend.question.repository;
 
 import com.backend.question.domain.Question;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/backend/scrap/controller/MessageScrapController.java
+++ b/src/main/java/com/backend/scrap/controller/MessageScrapController.java
@@ -71,7 +71,7 @@ public class MessageScrapController {
     public ResponseEntity<List<ScrapMessageDTO>> getUserScraps(
             @PathVariable String targetUserId
     ) {
-        List<ScrapMessageDTO> list = messageScrapService.getMyScraps(targetUserId);
+        List<ScrapMessageDTO> list = messageScrapService.getUserScraps(targetUserId);
         return ResponseEntity.ok(list);
     }
 }

--- a/src/main/java/com/backend/search/controller/SearchController.java
+++ b/src/main/java/com/backend/search/controller/SearchController.java
@@ -1,0 +1,49 @@
+package com.backend.search.controller;
+
+import com.backend.search.dto.SearchRequestDTO;
+import com.backend.search.dto.SearchResponseDTO;
+import com.backend.search.service.PopularSearchService;
+import com.backend.search.service.RecentSearchService;
+import com.backend.search.service.SearchService;
+import com.backend.security.auth.user.CustomUserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Search - Unified", description = "통합 검색 API (질문 + 콘텐츠 + 태그)")
+@RestController
+@RequestMapping("/api/v1/search")
+@RequiredArgsConstructor
+public class SearchController {
+
+    private final SearchService searchService;
+    private final RecentSearchService recentSearchService;
+    private final PopularSearchService popularSearchService;
+
+    @Operation(summary = "통합 검색", description = "질문, 콘텐츠, 태그를 한 번에 검색합니다.")
+    @PostMapping("/unified")
+    public ResponseEntity<SearchResponseDTO> unifiedSearch(
+            @AuthenticationPrincipal CustomUserPrincipal me,
+            @RequestBody SearchRequestDTO request,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        String keyword = request.keyword();
+
+        // 1) 최근 검색어 + 인기 검색어 반영
+        if (keyword != null && !keyword.isBlank()) {
+            if (me != null) {
+                recentSearchService.addKeyword(me.getUserId(), keyword);
+            }
+            popularSearchService.increase(keyword);
+        }
+
+        // 2) 실제 검색
+        SearchResponseDTO result = searchService.unifiedSearch(keyword, pageable);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/backend/search/controller/SearchController.java
+++ b/src/main/java/com/backend/search/controller/SearchController.java
@@ -15,6 +15,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Tag(name = "Search - Unified", description = "통합 검색 API (질문 + 콘텐츠 + 태그)")
 @RestController
 @RequestMapping("/api/v1/search")
@@ -33,6 +35,7 @@ public class SearchController {
             @PageableDefault(size = 20) Pageable pageable
     ) {
         String keyword = request.keyword();
+        List<Long> categoryIds = request.categoryIds();
 
         // 1) 최근 검색어 + 인기 검색어 반영
         if (keyword != null && !keyword.isBlank()) {
@@ -43,7 +46,7 @@ public class SearchController {
         }
 
         // 2) 실제 검색
-        SearchResponseDTO result = searchService.unifiedSearch(keyword, pageable);
+        SearchResponseDTO result = searchService.unifiedSearch(keyword, categoryIds, pageable);
         return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/backend/search/dto/ContentSearchItemDTO.java
+++ b/src/main/java/com/backend/search/dto/ContentSearchItemDTO.java
@@ -1,0 +1,8 @@
+package com.backend.search.dto;
+
+public record ContentSearchItemDTO(
+    Long id,
+    String name,
+    String creator
+) {
+}

--- a/src/main/java/com/backend/search/dto/QuestionSearchItemDTO.java
+++ b/src/main/java/com/backend/search/dto/QuestionSearchItemDTO.java
@@ -1,0 +1,8 @@
+package com.backend.search.dto;
+
+public record QuestionSearchItemDTO(
+    Long id,
+    String title,
+    String description
+) {
+}

--- a/src/main/java/com/backend/search/dto/SearchRequestDTO.java
+++ b/src/main/java/com/backend/search/dto/SearchRequestDTO.java
@@ -1,0 +1,5 @@
+package com.backend.search.dto;
+
+public record SearchRequestDTO(
+    String keyword
+) {}

--- a/src/main/java/com/backend/search/dto/SearchRequestDTO.java
+++ b/src/main/java/com/backend/search/dto/SearchRequestDTO.java
@@ -1,5 +1,8 @@
 package com.backend.search.dto;
 
+import java.util.List;
+
 public record SearchRequestDTO(
-    String keyword
+    String keyword,
+    List<Long> categoryIds
 ) {}

--- a/src/main/java/com/backend/search/dto/SearchResponseDTO.java
+++ b/src/main/java/com/backend/search/dto/SearchResponseDTO.java
@@ -1,0 +1,9 @@
+package com.backend.search.dto;
+
+import java.util.List;
+
+public record SearchResponseDTO (
+    List<QuestionSearchItemDTO> questions,
+    List<ContentSearchItemDTO> contents,
+    List<TagSearchItemDTO> tags
+) {}

--- a/src/main/java/com/backend/search/dto/TagSearchItemDTO.java
+++ b/src/main/java/com/backend/search/dto/TagSearchItemDTO.java
@@ -1,0 +1,7 @@
+package com.backend.search.dto;
+
+public record TagSearchItemDTO(
+    Long id,
+    String name
+) {
+}

--- a/src/main/java/com/backend/search/service/SearchService.java
+++ b/src/main/java/com/backend/search/service/SearchService.java
@@ -1,0 +1,73 @@
+package com.backend.search.service;
+
+import com.backend.content.repository.ContentRepository;
+import com.backend.question.repository.QuestionRepository;
+import com.backend.search.dto.ContentSearchItemDTO;
+import com.backend.search.dto.QuestionSearchItemDTO;
+import com.backend.search.dto.SearchResponseDTO;
+import com.backend.search.dto.TagSearchItemDTO;
+import com.backend.tag.Tag;
+import com.backend.tag.TagSearchRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SearchService {
+
+    private final QuestionRepository questionRepository;
+    private final ContentRepository contentRepository;
+    private final TagSearchRepository tagRepository;
+
+    public SearchResponseDTO unifiedSearch(String rawKeyword, Pageable pageable) {
+        if (rawKeyword == null || rawKeyword.isBlank()) {
+            return new SearchResponseDTO(List.of(), List.of(), List.of());
+        }
+
+        String keyword = rawKeyword.trim();
+
+        // 1) 질문 검색
+        var questionPage = questionRepository
+                .findByTitleContainingIgnoreCaseOrDescriptionContainingIgnoreCase(
+                        keyword, keyword, pageable
+                );
+
+        List<QuestionSearchItemDTO> questionDtos = questionPage.getContent().stream()
+                .map(q -> new QuestionSearchItemDTO(
+                        q.getId(),
+                        q.getTitle(),
+                        q.getDescription()
+                ))
+                .toList();
+
+        // 2) 콘텐츠 검색
+        var contentPage = contentRepository
+                .findByNameContainingIgnoreCaseOrDescriptionContainingIgnoreCase(
+                    keyword,
+                    keyword,
+                    pageable
+                );
+
+        List<ContentSearchItemDTO> contentDtos = contentPage.getContent().stream()
+                .map(c -> new ContentSearchItemDTO(
+                        c.getId(),
+                        c.getName(),
+                        c.getCreator()
+                ))
+                .toList();
+
+        // 3) 태그 검색 (상위 10개 정도만)
+        List<Tag> tags = tagRepository.findTop10ByNameContainingIgnoreCase(keyword);
+        List<TagSearchItemDTO> tagDtos = tags.stream()
+                .map(t -> new TagSearchItemDTO(
+                        t.getId(),
+                        t.getName()
+                ))
+                .toList();
+
+        return new SearchResponseDTO(questionDtos, contentDtos, tagDtos);
+    }
+}

--- a/src/main/java/com/backend/search/service/SearchService.java
+++ b/src/main/java/com/backend/search/service/SearchService.java
@@ -22,7 +22,7 @@ public class SearchService {
     private final ContentRepository contentRepository;
     private final TagSearchRepository tagRepository;
 
-    public SearchResponseDTO unifiedSearch(String rawKeyword, Pageable pageable) {
+    public SearchResponseDTO unifiedSearch(String rawKeyword, List<Long> categoryIds, Pageable pageable) {
         if (rawKeyword == null || rawKeyword.isBlank()) {
             return new SearchResponseDTO(List.of(), List.of(), List.of());
         }

--- a/src/main/java/com/backend/tag/TagSearchRepository.java
+++ b/src/main/java/com/backend/tag/TagSearchRepository.java
@@ -1,0 +1,11 @@
+package com.backend.tag;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TagSearchRepository extends JpaRepository<Tag, Long> {
+
+    // 검색어가 들어간 태그 상위 10개
+    List<Tag> findTop10ByNameContainingIgnoreCase(String name);
+}


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #56 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
#### 1) SearchService – 통합 검색 로직 구현
- 질문(Question), 콘텐츠(Content), 태그(Tag)를 한 번에 검색하는 unifiedSearch() 구현
- Pageable 기반 페이징 처리 완료
- 검색 결과를 `questions`, `contents`, `tags` 로 분리하여 DTO로 응답
- Content 엔티티 구조에 맞춰 검색 필드(name, description) 기반 검색으로 수정
- JPA Repository 메서드 추가 및 정리 완료

#### 2) 최근 검색어 / 인기 검색어 기능 연동
- 로그인 사용자일 경우 → RecentSearchService.addKeyword(userId, keyword) 저장
- 모든 사용자 → PopularSearchService.increase(keyword) 증가
- 키워드가 공백일 경우에는 저장/증가 처리 제외

#### 3) SearchController 구현
- `POST /api/v1/search/unified` 엔드포인트 구현
- JSON Body → `{"keyword": "AI"}` 방식으로 검색
- Swagger 문서화 추가
- @AuthenticationPrincipal 문제 해결 (Spring Security Config 정상 적용)

#### 4) Repository 수정 (중요)
- ContentRepository에서 title 기반 검색 제거
- `findByNameContainingIgnoreCase` + `findByDescriptionContainingIgnoreCase` 로 교체
- QuestionRepository도 동일하게 Where 조건 수정

#### 5) 테스트 및 검증
- 포스트맨에서 질문/콘텐츠/태그가 모두 정상적으로 검색되는 것 확인
- 최근 검색어/인기 검색어 카운트 정상 반영 확인
- JWT 필터 정상 작동 확인
- Anonymous 로그(인증 없음)에서도 검색 기능은 정상적으로 동작하는지 확인
## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
