### PR TITLE
[FEAT] 메시지 스크랩 기능 확장 (내부/외부 방 구분)

### DIFF
--- a/src/main/java/com/backend/room/repository/RoomParticipantRepository.java
+++ b/src/main/java/com/backend/room/repository/RoomParticipantRepository.java
@@ -1,0 +1,8 @@
+package com.backend.room.repository;
+
+import com.backend.roomMember.domain.RoomMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomParticipantRepository extends JpaRepository<RoomMember, Long> {
+    boolean existsByRoomIdAndMemberId(Long roomId, Long memberId);
+}

--- a/src/main/java/com/backend/scrap/controller/MessageScrapController.java
+++ b/src/main/java/com/backend/scrap/controller/MessageScrapController.java
@@ -22,7 +22,7 @@ public class MessageScrapController {
 
     private final MessageScrapService messageScrapService;
 
-    @Operation(summary = "메시지 스크랩")
+    @Operation(summary = "메시지 스크랩(내가 참여한 방 -> 마이페이지: 저장)")
     @PostMapping("/{messageId}/scrap")
     public ResponseEntity<MessageScrapResponseDTO> scrap(
             @AuthenticationPrincipal CustomUserPrincipal me,
@@ -33,11 +33,25 @@ public class MessageScrapController {
         }
 
         String userId = me.getUserId();
-        MessageScrapResponseDTO dto = messageScrapService.scrap(userId, messageId);
+        MessageScrapResponseDTO dto = messageScrapService.scrapFromMyRoom(userId, messageId);
         return ResponseEntity.ok(dto);
     }
 
-    @Operation(summary = "메시지 스크랩 취소")
+    // 내가 참여하지 않은 톡방에서 스크랩
+    @Operation(summary = "메시지 스크랩 (참여하지 않은 방 -> 마이페이지: 스크랩)")
+    @PostMapping("/{messageId}/scrap/external")
+    public ResponseEntity<MessageScrapResponseDTO> scrapFromExternal(
+            @AuthenticationPrincipal CustomUserPrincipal me,
+            @PathVariable Long messageId
+    ) {
+        if (me == null) throw new AuthError("unauthorized", "로그인이 필요합니다.");
+        String userId = me.getUserId();
+
+        MessageScrapResponseDTO dto = messageScrapService.scrapFromExternal(userId, messageId);
+        return ResponseEntity.ok(dto);
+    }
+
+    @Operation(summary = "메시지 스크랩 취소 (본인이 참여한 방, 미참여한 방 둘 다 작동)")
     @DeleteMapping("/{messageId}/scrap")
     public ResponseEntity<MessageScrapResponseDTO> unscrap(
             @AuthenticationPrincipal CustomUserPrincipal me,
@@ -74,4 +88,6 @@ public class MessageScrapController {
         List<ScrapMessageDTO> list = messageScrapService.getUserScraps(userId);
         return ResponseEntity.ok(list);
     }
+
+
 }

--- a/src/main/java/com/backend/scrap/dto/MessageScrapResponseDTO.java
+++ b/src/main/java/com/backend/scrap/dto/MessageScrapResponseDTO.java
@@ -12,5 +12,6 @@ import java.time.LocalDateTime;
 public record MessageScrapResponseDTO(
         Long messageId,
         boolean scrapped,
+        String source,        // "MY_ROOM" | "EXTERNAL"
         LocalDateTime scrappedAt
 ) {}

--- a/src/main/java/com/backend/scrap/service/MessageScrapService.java
+++ b/src/main/java/com/backend/scrap/service/MessageScrapService.java
@@ -9,6 +9,7 @@ import com.backend.scrap.dto.MessageScrapResponseDTO;
 import com.backend.scrap.dto.ScrapMessageDTO;
 import com.backend.scrap.repository.MessageScrapRepository;
 import com.backend.security.auth.exception.AuthError;
+import com.backend.room.repository.RoomParticipantRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,28 +25,66 @@ public class MessageScrapService {
     private final MessageScrapRepository messageScrapRepository;
     private final MemberRepository memberRepository;
     private final MessageRepository messageRepository;
+    private final RoomParticipantRepository roomMemberRepository;
 
-    /**
-     * 메시지 스크랩 추가 (이미 스크랩 상태면 그대로 유지 - idempotent)
-     */
-    public MessageScrapResponseDTO scrap(String userId, Long messageId) {
-        Member me = memberRepository.findByUserId(userId)
+    private Member getMember(String userId) {
+        return memberRepository.findByUserId(userId)
                 .orElseThrow(() -> new AuthError("not_found_member", "존재하지 않는 회원입니다."));
+        }
 
-        Message message = messageRepository.findById(messageId)
-                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 메시지입니다."));
+    private Message getMessage(Long messageId) {
+    return messageRepository.findById(messageId)
+            .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 메시지입니다."));
+    }
 
-        return messageScrapRepository.findByMemberAndMessage(me, message)
-                .map(scrap -> new MessageScrapResponseDTO(
-                        message.getId(),
+    // 
+    // 내가 참여한 방에서 스크랩
+    // 
+    public MessageScrapResponseDTO scrapFromMyRoom(String userId, Long messageId) {
+
+        Member me = getMember(userId);
+        Message msg = getMessage(messageId);
+        var roomId = msg.getRoom().getId();
+
+        boolean isParticipant =
+                        roomMemberRepository.existsByRoomIdAndMemberId(roomId, me.getId());
+
+        if (!isParticipant) {
+            throw new AuthError("not_participant", "해당 채팅방에 참여하지 않았습니다.");
+        }
+
+        return saveScrap(me, msg, "MY_ROOM");
+    }
+
+    // 
+    // 참여하지 않은 방에서 스크랩
+    // 
+    public MessageScrapResponseDTO scrapFromExternal(String userId, Long messageId) {
+        Member me = getMember(userId);
+        Message msg = getMessage(messageId);
+
+        return saveScrap(me, msg, "EXTERNAL");
+    }
+
+    // 
+    // 공통 저장 로직
+    // 
+    private MessageScrapResponseDTO saveScrap(Member me, Message msg, String source) {
+
+        return messageScrapRepository.findByMemberAndMessage(me, msg)
+                .map(s -> new MessageScrapResponseDTO(
+                        msg.getId(),
                         true,
-                        scrap.getScrappedAt()
+                        source,
+                        s.getScrappedAt()
                 ))
                 .orElseGet(() -> {
-                    MessageScrap saved = messageScrapRepository.save(MessageScrap.of(me, message));
+                    MessageScrap saved = messageScrapRepository.save(MessageScrap.of(me, msg));
+
                     return new MessageScrapResponseDTO(
-                            message.getId(),
+                            msg.getId(),
                             true,
+                            source,
                             saved.getScrappedAt()
                     );
                 });
@@ -65,7 +104,7 @@ public class MessageScrapService {
                 .ifPresent(messageScrapRepository::delete);
 
         // scrappedAt 은 이제 의미 없으니 null
-        return new MessageScrapResponseDTO(message.getId(), false, null);
+        return new MessageScrapResponseDTO(message.getId(), false, null, null);
     }
 
     /**

--- a/src/main/java/com/backend/security/config/SecurityConfig.java
+++ b/src/main/java/com/backend/security/config/SecurityConfig.java
@@ -56,7 +56,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.DELETE, "/api/v1/questions/*/like").authenticated()
 
                 // 메시지 스크랩
-                .requestMatchers(HttpMethod.POST, "/api/v1/messages/*/scrap").authenticated()
+                .requestMatchers(HttpMethod.POST, "/api/v1/messages/*/scrap/**").authenticated()
                 .requestMatchers(HttpMethod.DELETE, "/api/v1/messages/*/scrap").authenticated()
                 .requestMatchers(HttpMethod.GET, "/api/v1/messages/scrap/me").authenticated()
                 .requestMatchers(HttpMethod.GET,    "/api/v1/messages/scrap/*").authenticated()


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #70 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
1. 메시지 스크랩 기능 확장
   - 내가 참여한 톡방에서 스크랩
     - `POST /api/v1/messages/{messageId}/scrap/my-room`
     - `room_member` 기준으로 방 참여 여부 검증
   - 내가 참여하지 않은 톡방에서 스크랩
     - `POST /api/v1/messages/{messageId}/scrap/external`
     - 방 참여 여부 검증 없이 스크랩 생성
   - 스크랩 삭제 공통 처리
     - `DELETE /api/v1/messages/{messageId}/scrap`
     - MY_ROOM / EXTERNAL 모두 동일하게 삭제

2. Room/참여자 레포지토리 정리
   - 방 참여 여부 전용 레포지토리 분리
     - `RoomMemberParticipationRepository` (예: 패키지 `com.backend.roomMember.repository`)
     - 메서드: `boolean existsByRoomIdAndMemberId(Long roomId, Long memberId)`
   - `RoomRepository`에서 잘못된 메서드 제거
     - `existsByMemberAndRoom(...)` 제거
   - `QuestionService`, `MessageScrapService` 등에서 방 참여 체크 시
     - `RoomRepository` → `RoomMemberParticipationRepository` 사용하도록 수정

3. MessageScrapService 리팩토링
   - 공통 조회 유틸 메서드 추가
     - `private Member getMember(String userId)`
     - `private Message getMessage(Long messageId)`
   - 스크랩 처리 메서드 분리
     - `scrapFromMyRoom(String userId, Long messageId)`
     - `scrapFromExternal(String userId, Long messageId)`
     - 내부 공통 로직: `saveScrap(Member me, Message msg, String source)`
   - 삭제 메서드 유지/보완
     - `unscrap(String userId, Long messageId)`  
     - 소스 종류와 무관하게 항상 내 스크랩 레코드 삭제

## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
