### PR TITLE
[FIX] 카카오 로그인 수정

### DIFF
--- a/src/main/java/com/backend/security/auth/controller/KakaoAuthController.java
+++ b/src/main/java/com/backend/security/auth/controller/KakaoAuthController.java
@@ -35,7 +35,7 @@ public class KakaoAuthController {
     @Operation(summary = "[서버 사이드] 인가코드로 카카오 로그인")
     @PostMapping("/login-by-code")
     public ResponseEntity<TokenIssueResultDTO> loginByCode(@Valid @RequestBody KakaoLoginRequestDTO req) {
-        KakaoTokenResponseDTO token = kakao.exchangeCodeForToken(req.code());
+        KakaoTokenResponseDTO token = kakao.exchangeCodeForToken(req.code(), req.redirectUri());
         KakaoUserResponseDTO user = kakao.fetchUser(token.accessToken());
 
         String socialId = String.valueOf(user.id());

--- a/src/main/java/com/backend/security/oauth/kakao/KakaoOAuthClient.java
+++ b/src/main/java/com/backend/security/oauth/kakao/KakaoOAuthClient.java
@@ -20,11 +20,11 @@ public class KakaoOAuthClient {
     }
 
     // 1) 인가코드 → 카카오 액세스 토큰
-    public KakaoTokenResponseDTO exchangeCodeForToken(String code) {
+    public KakaoTokenResponseDTO exchangeCodeForToken(String code, String redirectUri) {
         String body = "grant_type=authorization_code" +
                 "&client_id=" + enc(props.getClientId()) +
                 (isBlank(props.getClientSecret()) ? "" : "&client_secret=" + enc(props.getClientSecret())) +
-                "&redirect_uri=" + enc(props.getRedirectUri()) +
+                "&redirect_uri=" + enc(redirectUri) +
                 "&code=" + enc(code);
 
         return webClient.post()

--- a/src/main/java/com/backend/security/oauth/kakao/dto/KakaoLoginRequestDTO.java
+++ b/src/main/java/com/backend/security/oauth/kakao/dto/KakaoLoginRequestDTO.java
@@ -4,5 +4,6 @@ import jakarta.validation.constraints.NotBlank;
 
 // 클라이언트로부터 받는 인가코드 DTO
 public record KakaoLoginRequestDTO(
-        @NotBlank String code
+        @NotBlank String code,
+        @NotBlank String redirectUri
 ) {}


### PR DESCRIPTION
## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #75 

## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
카카오 로그인 관련 post 요청에서 redirect uri를 프론트 측에서 받아와 사용하도록 수정하였습니다.

## 📚 Reference
보안 이슈를 이유로 로그인 과정에서 인가코드 발급과 액세스 토큰 발급에 사용한 Redirect URI는 동일해야한다고 합니다.
따라서 프론트 측이 인가코드 발급시 사용한 코드를 가져와 백엔드에서도 사용하도록 개선하였습니다.

https://datatracker.ietf.org/doc/html/rfc6749#page-56
<img width="500" height="400" alt="image" src="https://github.com/user-attachments/assets/51100309-c374-4492-82d1-53e6214c7c5b" />



### ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 포스트맨에서 결과값을 제대로 확인했나요?
- [ ] 리뷰어 설정을 지정했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
