### PR TITLE
[FEAT] 등록된 전체 콘텐츠 리스트 반환 api 구현

### DIFF
--- a/src/main/java/com/backend/category/domain/Category.java
+++ b/src/main/java/com/backend/category/domain/Category.java
@@ -1,6 +1,5 @@
 package com.backend.category.domain;
 
-import com.backend.categoryContent.CategoryContent;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/backend/categoryContent/CategoryContentRepository.java
+++ b/src/main/java/com/backend/categoryContent/CategoryContentRepository.java
@@ -1,6 +1,5 @@
 package com.backend.categoryContent;
 
-import com.backend.category.domain.Category;
 import com.backend.content.domain.Content;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/backend/config/QuerydslConfig.java
+++ b/src/main/java/com/backend/config/QuerydslConfig.java
@@ -3,7 +3,6 @@ package com.backend.config;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
-import lombok.Builder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/src/main/java/com/backend/content/controller/ContentController.java
+++ b/src/main/java/com/backend/content/controller/ContentController.java
@@ -2,11 +2,14 @@ package com.backend.content.controller;
 
 import com.backend.content.dto.ContentCreateRequestDTO;
 import com.backend.content.dto.ContentResponseDTO;
+import com.backend.content.dto.ContentWithCategoriesResponseDTO;
 import com.backend.content.service.ContentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/contents")
@@ -18,5 +21,12 @@ public class ContentController {
     public ResponseEntity<ContentResponseDTO> createContent(@RequestBody ContentCreateRequestDTO dto) {
         ContentResponseDTO responseDTO = contentService.createContent(dto);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDTO);
+    }
+
+    @GetMapping("/all")
+    public ResponseEntity<List<ContentWithCategoriesResponseDTO>> getAllContents() {
+        return ResponseEntity.ok(
+                contentService.getAllContentsWithCategories()
+        );
     }
 }

--- a/src/main/java/com/backend/content/domain/Content.java
+++ b/src/main/java/com/backend/content/domain/Content.java
@@ -1,13 +1,9 @@
 package com.backend.content.domain;
 
-import com.backend.categoryContent.CategoryContent;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Table(name = "contents")

--- a/src/main/java/com/backend/content/dto/ContentCategoryDTO.java
+++ b/src/main/java/com/backend/content/dto/ContentCategoryDTO.java
@@ -1,0 +1,6 @@
+package com.backend.content.dto;
+
+public record ContentCategoryDTO(
+    String mainCategory,
+    String subCategory
+) {}

--- a/src/main/java/com/backend/content/dto/ContentWithCategoriesResponseDTO.java
+++ b/src/main/java/com/backend/content/dto/ContentWithCategoriesResponseDTO.java
@@ -1,0 +1,11 @@
+package com.backend.content.dto;
+
+public record ContentWithCategoriesResponseDTO(
+    Long contentId,
+    String name,
+    String creator,
+    String description,
+    String imageUrl,
+    String link,
+    java.util.List<ContentCategoryDTO> categories
+) {}

--- a/src/main/java/com/backend/content/service/ContentService.java
+++ b/src/main/java/com/backend/content/service/ContentService.java
@@ -7,10 +7,16 @@ import com.backend.categoryContent.CategoryContentRepository;
 import com.backend.content.domain.Content;
 import com.backend.content.dto.ContentCreateRequestDTO;
 import com.backend.content.dto.ContentResponseDTO;
+import com.backend.content.dto.ContentWithCategoriesResponseDTO;
+import com.backend.content.dto.ContentCategoryDTO;
 import com.backend.content.repository.ContentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -35,5 +41,50 @@ public class ContentService {
 
 
         return ContentResponseDTO.from(savedContent, subCategory);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ContentWithCategoriesResponseDTO> getAllContentsWithCategories() {
+
+        // 1) 모든 콘텐츠 조회
+        List<Content> contents = contentRepository.findAll();
+        if (contents.isEmpty()) {
+            return List.of();
+        }
+
+        // 2) 해당 콘텐츠들에 연결된 CategoryContent 전부 한 번에 조회
+        List<CategoryContent> mappings = categoryContentRepository.findAllByContentIn(contents);
+
+        // 3) contentId 기준으로 그룹핑
+        Map<Long, List<CategoryContent>> byContentId = mappings.stream()
+                .collect(Collectors.groupingBy(cc -> cc.getContent().getId()));
+
+        // 4) DTO 변환
+        return contents.stream()
+                .map(content -> {
+                    List<CategoryContent> myMappings =
+                            byContentId.getOrDefault(content.getId(), List.of());
+
+                    List<ContentCategoryDTO> categories = myMappings.stream()
+                            .map(cc -> {
+                                Category sub = cc.getCategory();
+                                Category main = sub.getParent();   // 메인 카테고리 (없을 수도 있음)
+                                String mainName = (main != null) ? main.getName() : null;
+                                String subName  = sub.getName();
+                                return new ContentCategoryDTO(mainName, subName);
+                            })
+                            .toList();
+
+                    return new ContentWithCategoriesResponseDTO(
+                            content.getId(),
+                            content.getName(),
+                            content.getCreator(),
+                            content.getDescription(),
+                            content.getImageUrl(),
+                            content.getLink(),
+                            categories
+                    );
+                })
+                .toList();
     }
 }


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #81 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
1. **콘텐츠 + 카테고리 응답 DTO 추가**
   - `ContentWithCategoriesResponseDTO`
     - `Long contentId`
     - `String name`
     - `List<ContentCategoryDTO> categories`
   - `ContentCategoryDTO`
     - `Long categoryId`
     - `String name`
     - (필요 시 main/sub 구분 필드 추가 가능)

2. **Service 레이어 로직 추가**
   - `ContentService#getAllContentsWithCategories()`
     - `contentRepository.findAll()`로 전체 콘텐츠 조회
     - 각 콘텐츠에 매핑된 카테고리 정보를 조회 후 `ContentWithCategoriesResponseDTO`로 매핑

3. **Controller 엔드포인트 추가**
   - `ContentController`
     - `GET /api/v1/contents/all`
     - 등록된 모든 콘텐츠 + 카테고리 리스트 반환

## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
