### PR TITLE
[FEAT] 카카오 로그인 시 Access Token 헤더 담기 구현

### DIFF
--- a/src/main/java/com/backend/security/auth/controller/KakaoAuthController.java
+++ b/src/main/java/com/backend/security/auth/controller/KakaoAuthController.java
@@ -14,6 +14,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 
 @Tag(name = "SocialAuth", description = "카카오 소셜 로그인")
 @RestController
@@ -46,7 +48,29 @@ public class KakaoAuthController {
                 ? user.kakaoAccount().profile().profileImageUrl() : null;
 
         Member m = socialAuthService.upsertKakaoUser(socialId, email, nickname, profile);
-        return ResponseEntity.ok(authTokenService.issueTokensFor(m));
+
+        // 기존처럼 토큰 발급
+        TokenIssueResultDTO tokens = authTokenService.issueTokensFor(m);
+
+        // 1) Access Token → Authorization 헤더
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + tokens.accessToken());
+
+        // 2) Refresh Token → HttpOnly 쿠키
+        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", tokens.refreshToken())
+                .httpOnly(true)
+                .secure(false)          // https 환경이면 true 유지
+                .sameSite("None")
+                .path("/")
+                .maxAge(60 * 60 * 24 * 14)  // 14일
+                .build();
+
+        headers.add(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(tokens);
     }
 
     @Operation(summary = "[프론트/모바일] 카카오 access_token으로 로그인")
@@ -62,7 +86,28 @@ public class KakaoAuthController {
                 ? user.kakaoAccount().profile().profileImageUrl() : null;
 
         Member m = socialAuthService.upsertKakaoUser(socialId, email, nickname, profile);
-        return ResponseEntity.ok(authTokenService.issueTokensFor(m));
+
+        // 기존처럼 토큰 발급
+        TokenIssueResultDTO tokens = authTokenService.issueTokensFor(m);
+
+        // 1) Access Token → Authorization 헤더
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + tokens.accessToken());
+
+        // 2) Refresh Token → HttpOnly 쿠키
+        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", tokens.refreshToken())
+                .httpOnly(true)
+                .secure(false)          // https 환경이면 true 유지
+                .sameSite("None")
+                .path("/")
+                .maxAge(60 * 60 * 24 * 14)  // 14일
+                .build();
+
+        headers.add(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(tokens);
     }
-    
 }


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #83 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
두 엔드포인트(/login-by-code, /login-by-token) 모두 아래 변경을 적용:
	•	Access Token을 Authorization: Bearer <token> 헤더에 넣어 반환
	•	Refresh Token을 HttpOnly + Secure + SameSite=None 쿠키로 설정하여 반환
	•	기존 응답 body(TokenIssueResultDTO)는 그대로 유지하여 하위 호환성 보장

## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
