### PR TITLE
[REFACTOR] 메시지 스크랩 조회 및 인기 스크랩 API 리팩토링

### DIFF
--- a/src/main/java/com/backend/BackendApplication.java
+++ b/src/main/java/com/backend/BackendApplication.java
@@ -1,12 +1,7 @@
 package com.backend;
 
-import com.backend.notification.NotificationMessage;
-import com.backend.notification.NotificationPublisher;
-import com.backend.notification.NotificationType;
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 

--- a/src/main/java/com/backend/room/domain/Room.java
+++ b/src/main/java/com/backend/room/domain/Room.java
@@ -1,20 +1,26 @@
 package com.backend.room.domain;
 
+import com.backend.question.domain.Question;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "rooms")
 @Getter
+@NoArgsConstructor
 public class Room {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    //TODO: Message도 양방향으로 추가하는 게 좋을 듯...? Base Entitiy 추가
+    // ⭐ 방은 하나의 질문에 속한다.
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id")
+    private Question question;
 
-    public Room() {
+    public Room(Question question) {
+        this.question = question;
     }
-
-
 }

--- a/src/main/java/com/backend/scrap/controller/MessageScrapController.java
+++ b/src/main/java/com/backend/scrap/controller/MessageScrapController.java
@@ -26,7 +26,7 @@ public class MessageScrapController {
 
     private final MessageScrapService messageScrapService;
 
-    @Operation(summary = "메시지 스크랩(내가 참여한 방 -> 마이페이지: 저장)")
+    @Operation(summary = "메시지 스크랩")
     @PostMapping("/{messageId}/scrap")
     public ResponseEntity<MessageScrapResponseDTO> scrap(
             @AuthenticationPrincipal CustomUserPrincipal me,
@@ -37,25 +37,11 @@ public class MessageScrapController {
         }
 
         String userId = me.getUserId();
-        MessageScrapResponseDTO dto = messageScrapService.scrapFromMyRoom(userId, messageId);
+        MessageScrapResponseDTO dto = messageScrapService.scrapFromRoom(userId, messageId);
         return ResponseEntity.ok(dto);
     }
 
-    // 내가 참여하지 않은 톡방에서 스크랩
-    @Operation(summary = "메시지 스크랩 (참여하지 않은 방 -> 마이페이지: 스크랩)")
-    @PostMapping("/{messageId}/scrap/external")
-    public ResponseEntity<MessageScrapResponseDTO> scrapFromExternal(
-            @AuthenticationPrincipal CustomUserPrincipal me,
-            @PathVariable Long messageId
-    ) {
-        if (me == null) throw new AuthError("unauthorized", "로그인이 필요합니다.");
-        String userId = me.getUserId();
-
-        MessageScrapResponseDTO dto = messageScrapService.scrapFromExternal(userId, messageId);
-        return ResponseEntity.ok(dto);
-    }
-
-    @Operation(summary = "메시지 스크랩 취소 (본인이 참여한 방, 미참여한 방 둘 다 작동)")
+    @Operation(summary = "메시지 스크랩 취소")
     @DeleteMapping("/{messageId}/scrap")
     public ResponseEntity<MessageScrapResponseDTO> unscrap(
             @AuthenticationPrincipal CustomUserPrincipal me,
@@ -80,7 +66,7 @@ public class MessageScrapController {
         }
 
         String userId = me.getUserId();
-        List<ScrapMessageDTO> list = messageScrapService.getMyScraps(userId);
+        List<ScrapMessageDTO> list = messageScrapService.getScraps(userId);
         return ResponseEntity.ok(list);
     }
 
@@ -89,7 +75,7 @@ public class MessageScrapController {
     public ResponseEntity<List<ScrapMessageDTO>> getUserScraps(
             @PathVariable String userId
     ) {
-        List<ScrapMessageDTO> list = messageScrapService.getUserScraps(userId);
+        List<ScrapMessageDTO> list = messageScrapService.getScraps(userId);
         return ResponseEntity.ok(list);
     }
 

--- a/src/main/java/com/backend/scrap/dto/MessageScrapResponseDTO.java
+++ b/src/main/java/com/backend/scrap/dto/MessageScrapResponseDTO.java
@@ -12,6 +12,5 @@ import java.time.LocalDateTime;
 public record MessageScrapResponseDTO(
         Long messageId,
         boolean scrapped,
-        String source,        // "MY_ROOM" | "EXTERNAL"
         LocalDateTime scrappedAt
 ) {}

--- a/src/main/java/com/backend/scrap/dto/ScrapMessageDTO.java
+++ b/src/main/java/com/backend/scrap/dto/ScrapMessageDTO.java
@@ -1,17 +1,22 @@
 package com.backend.scrap.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 import java.time.LocalDateTime;
 
-/**
- * 내 스크랩 목록 조회용 DTO
- *
- * message 내용이나 room 정보가 필요하면
- * Message 엔티티에서 가져다가 추가하면 됨.
- */
-public record ScrapMessageDTO(
-        Long scrapId,
-        Long messageId,
-        Long roomId,
-        String content,
-        LocalDateTime scrappedAt
-) {}
+@Getter
+@AllArgsConstructor
+public class ScrapMessageDTO {
+
+    private Long messageId;
+    private String messageContent;
+
+    private Long questionId;
+    private String questionTitle;
+
+    private Long contentId;
+    private String contentTitle;
+
+    private LocalDateTime scrappedAt;
+}

--- a/src/main/java/com/backend/scrap/repository/MessageScrapRepository.java
+++ b/src/main/java/com/backend/scrap/repository/MessageScrapRepository.java
@@ -3,10 +3,12 @@ package com.backend.scrap.repository;
 import com.backend.member.domain.Member;
 import com.backend.message.domain.Message;
 import com.backend.scrap.dto.ScrappedMessageSummaryDTO;
+import com.backend.scrap.dto.ScrapMessageDTO;
 import com.backend.scrap.domain.MessageScrap;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -29,4 +31,23 @@ public interface MessageScrapRepository extends JpaRepository<MessageScrap, Long
         ORDER BY COUNT(ms.id) DESC
     """)
     List<ScrappedMessageSummaryDTO> findTopScrappedMessages(Pageable pageable);
+
+    @Query("""
+    select new com.backend.scrap.dto.ScrapMessageDTO(
+        m.id,
+        m.content,
+        q.id,
+        q.title,
+        c.id,
+        c.name,
+        s.scrappedAt
+    )
+    from MessageScrap s
+        join s.message m
+        join Question q on q.room = m.room
+        left join q.content c
+    where s.member.userId = :userId
+    order by s.scrappedAt desc
+    """)
+    List<ScrapMessageDTO> findScrapsByUserId(@Param("userId") String userId);
 }

--- a/src/main/java/com/backend/scrap/service/MessageScrapService.java
+++ b/src/main/java/com/backend/scrap/service/MessageScrapService.java
@@ -9,13 +9,13 @@ import com.backend.scrap.dto.MessageScrapResponseDTO;
 import com.backend.scrap.dto.ScrapMessageDTO;
 import com.backend.scrap.repository.MessageScrapRepository;
 import com.backend.security.auth.exception.AuthError;
-import com.backend.room.repository.RoomParticipantRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.backend.scrap.dto.ScrappedMessageSummaryDTO;
 import org.springframework.data.domain.PageRequest;
+
 
 import java.util.List;
 
@@ -27,7 +27,6 @@ public class MessageScrapService {
     private final MessageScrapRepository messageScrapRepository;
     private final MemberRepository memberRepository;
     private final MessageRepository messageRepository;
-    private final RoomParticipantRepository roomMemberRepository;
 
     private Member getMember(String userId) {
         return memberRepository.findByUserId(userId)
@@ -40,55 +39,17 @@ public class MessageScrapService {
     }
 
     // 
-    // 내가 참여한 방에서 스크랩
+    // 스크랩
     // 
-    public MessageScrapResponseDTO scrapFromMyRoom(String userId, Long messageId) {
-
+    public MessageScrapResponseDTO scrapFromRoom(String userId, Long messageId) {
         Member me = getMember(userId);
         Message msg = getMessage(messageId);
-        var roomId = msg.getRoom().getId();
-
-        boolean isParticipant =
-                        roomMemberRepository.existsByRoomIdAndMemberId(roomId, me.getId());
-
-        if (!isParticipant) {
-            throw new AuthError("not_participant", "해당 채팅방에 참여하지 않았습니다.");
-        }
-
-        return saveScrap(me, msg, "MY_ROOM");
-    }
-
-    // 
-    // 참여하지 않은 방에서 스크랩
-    // 
-    public MessageScrapResponseDTO scrapFromExternal(String userId, Long messageId) {
-        Member me = getMember(userId);
-        Message msg = getMessage(messageId);
-
-        return saveScrap(me, msg, "EXTERNAL");
-    }
-
-    // 
-    // 공통 저장 로직
-    // 
-    private MessageScrapResponseDTO saveScrap(Member me, Message msg, String source) {
 
         return messageScrapRepository.findByMemberAndMessage(me, msg)
-                .map(s -> new MessageScrapResponseDTO(
-                        msg.getId(),
-                        true,
-                        source,
-                        s.getScrappedAt()
-                ))
+                .map(s -> new MessageScrapResponseDTO(msg.getId(), true, s.getScrappedAt()))
                 .orElseGet(() -> {
                     MessageScrap saved = messageScrapRepository.save(MessageScrap.of(me, msg));
-
-                    return new MessageScrapResponseDTO(
-                            msg.getId(),
-                            true,
-                            source,
-                            saved.getScrappedAt()
-                    );
+                    return new MessageScrapResponseDTO(msg.getId(), true, saved.getScrappedAt());
                 });
     }
 
@@ -96,72 +57,21 @@ public class MessageScrapService {
      * 스크랩 취소 (없어도 에러 내지 않고 조용히 처리)
      */
     public MessageScrapResponseDTO unscrap(String userId, Long messageId) {
-        Member me = memberRepository.findByUserId(userId)
-                .orElseThrow(() -> new AuthError("not_found_member", "존재하지 않는 회원입니다."));
-
-        Message message = messageRepository.findById(messageId)
-                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 메시지입니다."));
-
+        Member me = getMember(userId);
+        Message message = getMessage(messageId);
+    
         messageScrapRepository.findByMemberAndMessage(me, message)
                 .ifPresent(messageScrapRepository::delete);
-
-        // scrappedAt 은 이제 의미 없으니 null
-        return new MessageScrapResponseDTO(message.getId(), false, null, null);
+    
+        return new MessageScrapResponseDTO(message.getId(), false, null);
     }
 
     /**
-     * 내 스크랩 목록 조회
+     * 스크랩 목록 조회
      */
     @Transactional(readOnly = true)
-    public List<ScrapMessageDTO> getMyScraps(String userId) {
-        Member me = memberRepository.findByUserId(userId)
-                .orElseThrow(() -> new AuthError("not_found_member", "존재하지 않는 회원입니다."));
-
-        List<MessageScrap> scraps = messageScrapRepository.findByMemberOrderByIdDesc(me);
-
-        return scraps.stream()
-                .map(scrap -> {
-                    Message m = scrap.getMessage();
-                    Long roomId = (m.getRoom() != null) ? m.getRoom().getId() : null;
-                    String content = m.getContent(); // Message 엔티티에 맞게 필드명 조정
-                    return new ScrapMessageDTO(
-                            scrap.getId(),
-                            m.getId(),
-                            roomId,
-                            content,
-                            scrap.getScrappedAt()
-                    );
-                })
-                .toList();
-    }
-
-    /**
-    * 특정 사용자의 스크랩 목록 조회 (친구 관계 검증 포함)
-    */
-    @Transactional(readOnly = true)
-    public List<ScrapMessageDTO> getUserScraps(String targetUserId) {
-
-    // 타겟 사용자 조회
-    Member target = memberRepository.findByUserId(targetUserId)
-            .orElseThrow(() -> new AuthError("not_found_target_member", "조회 대상 사용자가 존재하지 않습니다."));
-
-    // 스크랩 조회
-    List<MessageScrap> scraps = messageScrapRepository.findByMemberOrderByIdDesc(target);
-
-    return scraps.stream()
-        .map(scrap -> {
-                Message m = scrap.getMessage();
-                Long roomId = (m.getRoom() != null) ? m.getRoom().getId() : null;
-
-                return new ScrapMessageDTO(
-                        scrap.getId(),
-                        m.getId(),
-                        roomId,
-                        m.getContent(),
-                        scrap.getScrappedAt()
-                );
-        })
-        .toList();
+    public List<ScrapMessageDTO> getScraps(String userId) {
+        return messageScrapRepository.findScrapsByUserId(userId);
     }
 
     /**

--- a/src/main/java/com/backend/tagQuestion/TagQuestionRepository.java
+++ b/src/main/java/com/backend/tagQuestion/TagQuestionRepository.java
@@ -1,7 +1,6 @@
 package com.backend.tagQuestion;
 
 import com.backend.question.domain.Question;
-import com.backend.tag.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,7 +41,7 @@ app:
     secret: "WlV5b1p3ZjlxQmJvRzZyOXpZK0FteS1wSFh3czZfV2h5Zk1wbUhYd2s5S0pU"
     issuer: my-backend-api
     audience: web
-    access-token-validity-ms: 900000
+    access-token-validity-ms: 10800000   # 3 days
     refresh-token-validity-ms: 1209600000
     clock-skew-sec: 60
   oauth:


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #97 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
### 1. 스크랩 조회 응답 DTO 정리
- `ScrapMessageDTO`를 record → class + Lombok(@Getter, @AllArgsConstructor) 로 변경
- 응답 필드 구성
  - `messageId`, `messageContent`
  - `questionId`, `questionTitle`
  - `contentId`, `contentTitle`
  - `scrappedAt`

### 2. 유저별 스크랩 조회 쿼리 리팩토링
- `MessageScrapRepository.findScrapsByUserId(String userId)` JPQL 수정
  - `MessageScrap s`
  - `join s.message m`
  - `join m.room r`
  - `join Question q on q.room = r`
  - `left join q.content c`
  - `select new ScrapMessageDTO(...)` 로 바로 DTO 프로젝션
- 서비스 레이어에서의 추가 매핑 로직 제거

### 3. 스크랩 토글 로직 단순화
- `MessageScrapService`
  - 공통 멤버/메시지 조회 메서드 `getMember`, `getMessage` 추가
  - `scrapFromRoom(userId, messageId)`에서 참여방/미참여방 구분 없이 스크랩 처리
  - 이미 스크랩된 경우 재요청 시 동일한 상태 유지(idempotent)

### 4. 내/특정 유저 스크랩 조회 통합
- `MessageScrapService.getScraps(String userId)` 신규 메서드로 통합
- 컨트롤러에서
  - `/api/v1/messages/scrap/me` → 로그인 유저 기준 `getScraps(me.getUserId())`
  - `/api/v1/messages/scrap/{userId}` → `getScraps(userId)` 호출

### 5. 인기 스크랩 TOP N API 추가
- 레포지토리
  - `MessageScrapRepository.findTopScrappedMessages(Pageable pageable)`
  - `ScrappedMessageSummaryDTO(messageId, scrapCount)` 프로젝션
- 서비스
  - `MessageScrapService.getTopScrappedMessages(int size)` 구현
- 컨트롤러
  - `GET /api/v1/messages/scrap/popular?size=N`
  - 기본값 `size=10`, `@Min(1)`, `@Max(50)` 검증 추가

## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
