### PR TITLE
[FEAT] 질문에서 내 참여 상태 조회 구현

### DIFF
--- a/src/main/java/com/backend/question/domain/ParticipationStatus.java
+++ b/src/main/java/com/backend/question/domain/ParticipationStatus.java
@@ -1,0 +1,15 @@
+package com.backend.question.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ParticipationStatus {
+
+    NONE("참여 신청 안 함"),
+    WAITING("대기 중"),
+    JOINED("참여 중");
+
+    private final String description;
+}

--- a/src/main/java/com/backend/question/dto/response/QuestionResponseDTO.java
+++ b/src/main/java/com/backend/question/dto/response/QuestionResponseDTO.java
@@ -3,6 +3,7 @@ package com.backend.question.dto.response;
 import com.backend.category.domain.Category;
 import com.backend.question.domain.Question;
 import com.backend.question.domain.QuestionStatus;
+import com.backend.question.domain.ParticipationStatus;
 import com.backend.tag.Tag;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
@@ -26,10 +27,12 @@ public record QuestionResponseDTO(
         Integer currentParticipants,
         List<String> tagNames,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+
+        ParticipationStatus myParticipationStatus
         )
 {
-    public static QuestionResponseDTO from(Question question, Category subCategory, List<Tag> tags) {
+    public static QuestionResponseDTO from(Question question, Category subCategory, List<Tag> tags, ParticipationStatus myStatus) {
         List<String> tagNames = tags.stream()
                 .map(Tag::getName)
                 .toList();
@@ -58,7 +61,8 @@ public record QuestionResponseDTO(
                 question.getMaxParticipants(),
                 question.getCurrentParticipants(),
                 tagNames,
-                question.getCreatedAt()
+                question.getCreatedAt(),
+                myStatus
         );
     }
 }

--- a/src/main/java/com/backend/question/service/QuestionDtoAssembler.java
+++ b/src/main/java/com/backend/question/service/QuestionDtoAssembler.java
@@ -5,6 +5,7 @@ import com.backend.categoryContent.CategoryContent;
 import com.backend.categoryContent.CategoryContentRepository;
 import com.backend.content.domain.Content;
 import com.backend.question.domain.Question;
+import com.backend.question.domain.ParticipationStatus;
 import com.backend.question.dto.response.QuestionResponseDTO;
 import com.backend.tag.Tag;
 import com.backend.tagQuestion.TagQuestionRepository;
@@ -24,20 +25,23 @@ public class QuestionDtoAssembler {
     private final TagQuestionRepository tagQuestionRepository;
     private final CategoryContentRepository categoryContentRepository;
 
-    public Page<QuestionResponseDTO> toPageDto(Page<Question> questionPage) {
+    public Page<QuestionResponseDTO> toPageDto(Page<Question> questionPage, Map<Long, ParticipationStatus> myStatusMap
+    ) {
         List<Question> questions = questionPage.getContent();
 
         Map<Long, List<Tag>> questionTagMap = getQuestionTagMap(questions);
         Map<Long, Category> contentCategoryMap = getContentCategoryMap(questions);
-
+        
         return questionPage.map(question -> {
             List<Tag> tags = questionTagMap.getOrDefault(question.getId(), Collections.emptyList());
             Category category = contentCategoryMap.get(question.getContent().getId());
-            return QuestionResponseDTO.from(question, category, tags);
+            ParticipationStatus myStatus = myStatusMap.getOrDefault(question.getId(), ParticipationStatus.NONE);
+            
+            return QuestionResponseDTO.from(question, category, tags, myStatus);
         });
     }
 
-    public List<QuestionResponseDTO> toListDto(List<Question> questions) {
+    public List<QuestionResponseDTO> toListDto(List<Question> questions, Map<Long, ParticipationStatus> myStatusMap) {
         if (questions.isEmpty()) {
             return Collections.emptyList();
         }
@@ -51,7 +55,9 @@ public class QuestionDtoAssembler {
                 .map(question -> {
                     List<Tag> tags = questionTagMap.getOrDefault(question.getId(), Collections.emptyList());
                     Category category = contentCategoryMap.get(question.getContent().getId());
-                    return QuestionResponseDTO.from(question, category, tags);
+                    ParticipationStatus myStatus = myStatusMap.getOrDefault(question.getId(), ParticipationStatus.NONE);
+
+                    return QuestionResponseDTO.from(question, category, tags, myStatus);
                 })
                 .toList();
     }

--- a/src/main/java/com/backend/question/service/QuestionService.java
+++ b/src/main/java/com/backend/question/service/QuestionService.java
@@ -9,6 +9,7 @@ import com.backend.notification.NotificationMessage;
 import com.backend.notification.NotificationPublisher;
 import com.backend.notification.NotificationRepository;
 import com.backend.notification.NotificationType;
+import com.backend.question.domain.ParticipationStatus;
 import com.backend.question.domain.Question;
 import com.backend.question.domain.QuestionStatus;
 import com.backend.question.dto.request.CreateFirstQuestionRequestDTO;
@@ -35,6 +36,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -157,8 +159,14 @@ public class QuestionService {
                 .orElseThrow(() -> new RuntimeException("member not found"));
 
         List<Question> questions = questionRepository.findByHost(member);
-        return questionDtoAssembler.toListDto(questions);
 
+        Map<Long, ParticipationStatus> myStatusMap = questions.stream()
+        .collect(Collectors.toMap(
+                Question::getId,
+                q -> ParticipationStatus.JOINED
+        ));
+
+        return questionDtoAssembler.toListDto(questions, myStatusMap);
     }
 
     //TODO: questionDTOAssembler 사용
@@ -195,7 +203,20 @@ public class QuestionService {
         } else {
             questions = questionRepository.findByRoomIn(myRooms);
         }
-        return questionDtoAssembler.toListDto(questions);
+
+        Map<Long, ParticipationStatus> myStatusMap = questions.stream()
+                .collect(Collectors.toMap(
+                        Question::getId,
+                        q -> {
+                            if (q.getStatus() == QuestionStatus.ACTIVE) {
+                                return ParticipationStatus.JOINED;
+                            } else {
+                                return ParticipationStatus.WAITING;
+                            }
+                        }
+                ));
+
+        return questionDtoAssembler.toListDto(questions, myStatusMap);
     }
 
     //TODO: 질문 상세 조회
@@ -270,6 +291,9 @@ public class QuestionService {
     //TODO: 검색
     public Page<QuestionResponseDTO> searchQuestions(QuestionSearchRequestDTO dto, Pageable pageable) {
         Page<Question> questionPage = questionRepository.search(dto, pageable);
-        return questionDtoAssembler.toPageDto(questionPage);
+        return questionDtoAssembler.toPageDto(
+            questionPage,
+            java.util.Collections.emptyMap()   // 모두 ParticipationStatus.NONE 처리
+    );
     }
 }

--- a/src/main/java/com/backend/room/domain/Room.java
+++ b/src/main/java/com/backend/room/domain/Room.java
@@ -1,26 +1,20 @@
 package com.backend.room.domain;
 
-import com.backend.question.domain.Question;
 import jakarta.persistence.*;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "rooms")
 @Getter
-@NoArgsConstructor
 public class Room {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // ⭐ 방은 하나의 질문에 속한다.
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "question_id")
-    private Question question;
+    //TODO: Message도 양방향으로 추가하는 게 좋을 듯...? Base Entitiy 추가
 
-    public Room(Question question) {
-        this.question = question;
+    public Room() {
     }
+
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,7 +41,7 @@ app:
     secret: "WlV5b1p3ZjlxQmJvRzZyOXpZK0FteS1wSFh3czZfV2h5Zk1wbUhYd2s5S0pU"
     issuer: my-backend-api
     audience: web
-    access-token-validity-ms: 10800000   # 3 days
+    access-token-validity-ms: 10800000   # 3 hours
     refresh-token-validity-ms: 1209600000
     clock-skew-sec: 60
   oauth:


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #99 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
### 1. ParticipationStatus enum 추가
- `NONE` (참여 신청 안 함)
- `WAITING` (참여 신청 후 대기 중)
- `JOINED` (대화 참여 중)

### 2. QuestionResponseDTO에 myParticipationStatus 필드 추가
- DTO 필드 추가
- 정적 팩토리 메서드 시그니처 변경
- 기존 QuestionDtoAssembler 호출부 전체 수정 필요

### 3. QuestionDtoAssembler 수정
- `myParticipationStatus`를 외부에서 받아 DTO에 매핑하도록 구조 변경  
  (Map<Long, ParticipationStatus> 사용)

### 4. QuestionService 수정
- `getMyWrittenQuestions()` → 모든 질문에 대해 `JOINED`
- `getQuestions()` → RoomMember 기준으로 WAITING/JOINED 계산
- `searchQuestions()` → 모든 항목 `NONE`
- ParticipationStatus 계산 로직 추가
## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
