### PR TITLE
[FEAT] 인기 스크랩 메시지 상세 정보 응답 추가

### DIFF
--- a/src/main/java/com/backend/scrap/dto/ScrappedMessageSummaryDTO.java
+++ b/src/main/java/com/backend/scrap/dto/ScrappedMessageSummaryDTO.java
@@ -1,22 +1,14 @@
 package com.backend.scrap.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import java.time.LocalDateTime;
 
-@Getter
-@AllArgsConstructor
-public class ScrappedMessageSummaryDTO {
-
-    private Long messageId;
-    private String messageContent;
-
-    private Long questionId;
-    private String questionTitle;
-
-    private Long contentId;
-    private String contentTitle;
-
-    private Long scrapCount;
-    private LocalDateTime latestScrappedAt;
-}
+public record ScrappedMessageSummaryDTO(
+    Long messageId,
+    String messageContent,
+    Long questionId,
+    String questionTitle,
+    Long contentId,
+    String contentTitle,
+    Long scrapCount,
+    LocalDateTime latestScrappedAt
+) {}

--- a/src/main/java/com/backend/scrap/dto/ScrappedMessageSummaryDTO.java
+++ b/src/main/java/com/backend/scrap/dto/ScrappedMessageSummaryDTO.java
@@ -1,6 +1,21 @@
 package com.backend.scrap.dto;
 
-public record ScrappedMessageSummaryDTO(
-    Long messageId,
-    long scrapCount
-) {}
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ScrappedMessageSummaryDTO {
+
+    private Long messageId;
+    private String messageContent;
+
+    private Long questionId;
+    private String questionTitle;
+
+    private Long contentId;
+    private String contentTitle;
+
+    private Long scrapCount;
+    private java.time.LocalDateTime latestScrappedAt;
+}

--- a/src/main/java/com/backend/scrap/dto/ScrappedMessageSummaryDTO.java
+++ b/src/main/java/com/backend/scrap/dto/ScrappedMessageSummaryDTO.java
@@ -2,6 +2,7 @@ package com.backend.scrap.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
@@ -17,5 +18,5 @@ public class ScrappedMessageSummaryDTO {
     private String contentTitle;
 
     private Long scrapCount;
-    private java.time.LocalDateTime latestScrappedAt;
+    private LocalDateTime latestScrappedAt;
 }

--- a/src/main/java/com/backend/scrap/repository/MessageScrapRepository.java
+++ b/src/main/java/com/backend/scrap/repository/MessageScrapRepository.java
@@ -36,7 +36,7 @@ public interface MessageScrapRepository extends JpaRepository<MessageScrap, Long
     from MessageScrap s
         join s.message m
         join m.room r
-        join Question q on q.room = r
+        join Question q on q.room = r and q.status = 'ACTIVE'
         join q.content c
     group by m.id, m.content, q.id, q.title, c.id, c.name
     order by count(s) desc

--- a/src/main/java/com/backend/scrap/repository/MessageScrapRepository.java
+++ b/src/main/java/com/backend/scrap/repository/MessageScrapRepository.java
@@ -23,13 +23,23 @@ public interface MessageScrapRepository extends JpaRepository<MessageScrap, Long
     List<MessageScrap> findByMemberOrderByIdDesc(Member member);
 
     @Query("""
-        SELECT new com.backend.scrap.dto.ScrappedMessageSummaryDTO(
-            ms.message.id,
-            COUNT(ms.id)
-        )
-        FROM MessageScrap ms
-        GROUP BY ms.message.id
-        ORDER BY COUNT(ms.id) DESC
+    select new com.backend.scrap.dto.ScrappedMessageSummaryDTO(
+        m.id,
+        m.content,
+        q.id,
+        q.title,
+        c.id,
+        c.name,
+        count(s),
+        max(s.scrappedAt)
+    )
+    from MessageScrap s
+        join s.message m
+        join m.room r
+        join Question q on q.room = r
+        join q.content c
+    group by m.id, m.content, q.id, q.title, c.id, c.name
+    order by count(s) desc
     """)
     List<ScrappedMessageSummaryDTO> findTopScrappedMessages(Pageable pageable);
 


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #105 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
- 인기 스크랩 응답 DTO 확장
  - `ScrappedMessageSummaryDTO`에 아래 필드 추가
    - `messageContent`
    - `questionId`, `questionTitle`
    - `contentId`, `contentTitle`
    - `scrapCount`, `latestScrappedAt`
- `MessageScrapRepository.findTopScrappedMessages` JPQL 수정
  - `MessageScrap -> Message -> Room -> Question -> Content` 조인
  - 메시지/질문/콘텐츠 정보를 한 번에 조회하도록 projection 구성
- `MessageScrapService.getTopScrappedMessages(int size)`에서 확장된 DTO 그대로 반환

## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
