### PR TITLE
[FIX] 질문 검색 결과에 myParticipationStatus 값이 항상 NONE으로 내려오는 문제

### DIFF
--- a/src/main/java/com/backend/question/controller/QuestionController.java
+++ b/src/main/java/com/backend/question/controller/QuestionController.java
@@ -105,7 +105,7 @@ public class QuestionController {
             popularSearchService.increase(keyword);
         }
 
-        Page<QuestionResponseDTO> responses =  questionService.searchQuestions(questionSearchRequestDTO, pageable);
+        Page<QuestionResponseDTO> responses =  questionService.searchQuestions(me != null ? me.getUserId() : null, questionSearchRequestDTO, pageable);
         return ResponseEntity.status(HttpStatus.OK).body(responses);
     }
 

--- a/src/main/java/com/backend/question/service/QuestionService.java
+++ b/src/main/java/com/backend/question/service/QuestionService.java
@@ -304,11 +304,34 @@ public class QuestionService {
         return QuestionDTO.from(question);
     }
 
-    public Page<QuestionResponseDTO> searchQuestions(QuestionSearchRequestDTO dto, Pageable pageable) {
+    public Page<QuestionResponseDTO> searchQuestions(String userId, QuestionSearchRequestDTO dto, Pageable pageable) {
         Page<Question> questionPage = questionRepository.search(dto, pageable);
+        Map<Long, ParticipationStatus> myStatusMap = java.util.Collections.emptyMap();
+
+        if (userId != null) {
+            Member me = memberRepository.findByUserId(userId)
+                    .orElseThrow(() -> new RuntimeException("member not found"));
+    
+            // 내가 속한 방들
+            List<RoomMember> myRoomMembers = roomMemberRepository.findAllByMember(me);
+            java.util.Set<Long> myRoomIds = myRoomMembers.stream()
+                    .map(rm -> rm.getRoom().getId())
+                    .collect(java.util.stream.Collectors.toSet());
+    
+            // 이번 검색 결과 중, 내가 속한 방의 질문만 WAITING/JOINED로 표시
+            myStatusMap = questionPage.getContent().stream()
+                    .filter(q -> myRoomIds.contains(q.getRoom().getId()))
+                    .collect(Collectors.toMap(
+                            Question::getId,
+                            q -> (q.getStatus() == QuestionStatus.ACTIVE)
+                                    ? ParticipationStatus.JOINED
+                                    : ParticipationStatus.WAITING
+                    ));
+        }
+
         return questionDtoAssembler.toPageDto(
             questionPage,
-            java.util.Collections.emptyMap()   // 모두 ParticipationStatus.NONE 처리
+            myStatusMap
     );
     }
 }


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #109 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
### 1. QuestionService

```java
// before
public Page<QuestionResponseDTO> searchQuestions(QuestionSearchRequestDTO dto, Pageable pageable)

// after
public Page<QuestionResponseDTO> searchQuestions(String userId,
                                                 QuestionSearchRequestDTO dto,
                                                 Pageable pageable)

## 📚 Reference



### ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 포스트맨에서 결과값을 제대로 확인했나요?
- [ ] 리뷰어 설정을 지정했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
