### PR TITLE
[FEAT] 마이페이지 질문/스크랩 정렬 옵션 통합 및 정리

### DIFF
--- a/src/main/java/com/backend/question/controller/QuestionController.java
+++ b/src/main/java/com/backend/question/controller/QuestionController.java
@@ -46,7 +46,7 @@ public class QuestionController {
     @GetMapping("/my")
     public ResponseEntity<List<QuestionResponseDTO>> getMyWrittenQuestions(
             @AuthenticationPrincipal CustomUserPrincipal me,
-            @RequestParam(value = "order", required = false) String order
+            @RequestParam(value = "order", required = false, defaultValue = "latest") String order
         ) {
         List<QuestionResponseDTO> responseDTO = questionService.getMyWrittenQuestions(me.getUserId(), order);
         return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
@@ -56,7 +56,7 @@ public class QuestionController {
     public ResponseEntity<List<QuestionResponseDTO>> getMyQuestions(
             @AuthenticationPrincipal CustomUserPrincipal me,
             @RequestParam(value = "sort", required = false) String sort,
-            @RequestParam(value = "order", required = false) String order
+            @RequestParam(value = "order", required = false, defaultValue = "latest") String order
     ) {
 
         List<QuestionResponseDTO> responseDTOS = questionService.getQuestions(me.getUserId(), sort, order);

--- a/src/main/java/com/backend/question/controller/QuestionController.java
+++ b/src/main/java/com/backend/question/controller/QuestionController.java
@@ -44,15 +44,22 @@ public class QuestionController {
     }
 
     @GetMapping("/my")
-    public ResponseEntity<List<QuestionResponseDTO>> getMyWrittenQuestions(@AuthenticationPrincipal CustomUserPrincipal me) {
-        List<QuestionResponseDTO> responseDTO = questionService.getMyWrittenQuestions(me.getUserId());
+    public ResponseEntity<List<QuestionResponseDTO>> getMyWrittenQuestions(
+            @AuthenticationPrincipal CustomUserPrincipal me,
+            @RequestParam(value = "order", required = false) String order
+        ) {
+        List<QuestionResponseDTO> responseDTO = questionService.getMyWrittenQuestions(me.getUserId(), order);
         return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
     }
 
     @GetMapping
-    public ResponseEntity<List<QuestionResponseDTO>> getMyQuestions(@AuthenticationPrincipal CustomUserPrincipal me, @RequestParam(value = "sort", required = false) String sort) {
+    public ResponseEntity<List<QuestionResponseDTO>> getMyQuestions(
+            @AuthenticationPrincipal CustomUserPrincipal me,
+            @RequestParam(value = "sort", required = false) String sort,
+            @RequestParam(value = "order", required = false) String order
+    ) {
 
-        List<QuestionResponseDTO> responseDTOS = questionService.getQuestions(me.getUserId(),sort);
+        List<QuestionResponseDTO> responseDTOS = questionService.getQuestions(me.getUserId(), sort, order);
         return ResponseEntity.status(HttpStatus.OK).body(responseDTOS);
     }
 

--- a/src/main/java/com/backend/question/service/QuestionService.java
+++ b/src/main/java/com/backend/question/service/QuestionService.java
@@ -165,19 +165,17 @@ public class QuestionService {
 
         List<Question> questions = questionRepository.findByHost(member);
 
-        String effectiveOrder = (order == null || order.isBlank()) ? "latest" : order;
-        
-        List<Question> ordered = switch (effectiveOrder) {
+        List<Question> ordered = switch (order) {
             case "popular" -> questions.stream()
-                    .sorted(java.util.Comparator
+                    .sorted(Comparator
                             .comparingInt(Question::getCurrentParticipants)
                             .reversed())
                     .toList();
             case "oldest" -> questions.stream()
-                    .sorted(java.util.Comparator.comparing(Question::getCreatedAt))
+                    .sorted(Comparator.comparing(Question::getCreatedAt))
                     .toList();
             case "latest" -> questions.stream()
-                    .sorted(java.util.Comparator.comparing(Question::getCreatedAt).reversed())
+                    .sorted(Comparator.comparing(Question::getCreatedAt).reversed())
                     .toList();
             default -> questions;  // 이상한 값이면 그냥 원래 순서
         };
@@ -225,8 +223,8 @@ public class QuestionService {
             questions = questionRepository.findByRoomIn(myRooms);
         }
 
-        String effectiveOrder = (order == null || order.isBlank()) ? "latest" : order;
-
+        String effectiveOrder = order;
+        
         List<Question> ordered = switch (effectiveOrder) {
             case "popular" -> questions.stream()
                     .sorted(Comparator.comparingInt(Question::getCurrentParticipants).reversed())

--- a/src/main/java/com/backend/question/service/QuestionService.java
+++ b/src/main/java/com/backend/question/service/QuestionService.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.Comparator;
 
 @Service
 @RequiredArgsConstructor
@@ -158,11 +159,28 @@ public class QuestionService {
         return QuestionDTO.from(question);
     }
 
-    public List<QuestionResponseDTO> getMyWrittenQuestions(String userId) {
+    public List<QuestionResponseDTO> getMyWrittenQuestions(String userId, String order) {
         Member member =  memberRepository.findByUserId(userId)
                 .orElseThrow(() -> new RuntimeException("member not found"));
 
         List<Question> questions = questionRepository.findByHost(member);
+
+        String effectiveOrder = (order == null || order.isBlank()) ? "latest" : order;
+        
+        List<Question> ordered = switch (effectiveOrder) {
+            case "popular" -> questions.stream()
+                    .sorted(java.util.Comparator
+                            .comparingInt(Question::getCurrentParticipants)
+                            .reversed())
+                    .toList();
+            case "oldest" -> questions.stream()
+                    .sorted(java.util.Comparator.comparing(Question::getCreatedAt))
+                    .toList();
+            case "latest" -> questions.stream()
+                    .sorted(java.util.Comparator.comparing(Question::getCreatedAt).reversed())
+                    .toList();
+            default -> questions;  // 이상한 값이면 그냥 원래 순서
+        };
 
         Map<Long, ParticipationStatus> myStatusMap = questions.stream()
         .collect(Collectors.toMap(
@@ -170,10 +188,10 @@ public class QuestionService {
                 q -> ParticipationStatus.JOINED
         ));
 
-        return questionDtoAssembler.toListDto(questions, myStatusMap);
+        return questionDtoAssembler.toListDto(ordered, myStatusMap);
     }
 
-    public List<QuestionResponseDTO> getQuestions(String userId, String sort) {
+    public List<QuestionResponseDTO> getQuestions(String userId, String sort, String order) {
         Member member = memberRepository.findByUserId(userId)
                 .orElseThrow(() -> new RuntimeException("member not found"));
 
@@ -207,6 +225,21 @@ public class QuestionService {
             questions = questionRepository.findByRoomIn(myRooms);
         }
 
+        String effectiveOrder = (order == null || order.isBlank()) ? "latest" : order;
+
+        List<Question> ordered = switch (effectiveOrder) {
+            case "popular" -> questions.stream()
+                    .sorted(Comparator.comparingInt(Question::getCurrentParticipants).reversed())
+                    .toList();
+            case "oldest" -> questions.stream()
+                    .sorted(Comparator.comparing(Question::getCreatedAt))
+                    .toList();
+            case "latest" -> questions.stream()
+                    .sorted(Comparator.comparing(Question::getCreatedAt).reversed())
+                    .toList();
+            default -> questions; // 이상한 값 들어오면 그냥 기존 순서 유지
+        };
+
         Map<Long, ParticipationStatus> myStatusMap = questions.stream()
                 .collect(Collectors.toMap(
                         Question::getId,
@@ -219,7 +252,7 @@ public class QuestionService {
                         }
                 ));
 
-        return questionDtoAssembler.toListDto(questions, myStatusMap);
+        return questionDtoAssembler.toListDto(ordered, myStatusMap);
     }
     //TODO: N+1 문제 해결
     public QuestionDetailResponseDTO getQuestionDetailById(Long questionId) {

--- a/src/main/java/com/backend/scrap/controller/MessageScrapController.java
+++ b/src/main/java/com/backend/scrap/controller/MessageScrapController.java
@@ -59,23 +59,25 @@ public class MessageScrapController {
     @Operation(summary = "내 스크랩 메시지 목록 조회")
     @GetMapping("/scrap/me")
     public ResponseEntity<List<ScrapMessageDTO>> getMyScraps(
-            @AuthenticationPrincipal CustomUserPrincipal me
+            @AuthenticationPrincipal CustomUserPrincipal me,
+            @RequestParam(name = "order", defaultValue = "latest") String order
     ) {
         if (me == null) {
             throw new AuthError("unauthorized", "로그인이 필요합니다.");
         }
-
+    
         String userId = me.getUserId();
-        List<ScrapMessageDTO> list = messageScrapService.getScraps(userId);
+        List<ScrapMessageDTO> list = messageScrapService.getScraps(userId, order);
         return ResponseEntity.ok(list);
     }
 
     @Operation(summary = "특정 사용자의 스크랩 메시지 목록 조회")
     @GetMapping("/scrap/{userId}")
     public ResponseEntity<List<ScrapMessageDTO>> getUserScraps(
-            @PathVariable String userId
+            @PathVariable String userId,
+            @RequestParam(name = "order", defaultValue = "latest") String order
     ) {
-        List<ScrapMessageDTO> list = messageScrapService.getScraps(userId);
+        List<ScrapMessageDTO> list = messageScrapService.getScraps(userId, order);
         return ResponseEntity.ok(list);
     }
 

--- a/src/main/java/com/backend/scrap/repository/MessageScrapRepository.java
+++ b/src/main/java/com/backend/scrap/repository/MessageScrapRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 import java.util.Optional;
@@ -58,5 +59,5 @@ public interface MessageScrapRepository extends JpaRepository<MessageScrap, Long
         left join q.content c
     where s.member.userId = :userId
     """)
-    List<ScrapMessageDTO> findScrapsByUserId(@Param("userId") String userId, Sort sort);
+    Page<ScrapMessageDTO> findScrapsByUserId(@Param("userId") String userId, Pageable pageable);
 }

--- a/src/main/java/com/backend/scrap/repository/MessageScrapRepository.java
+++ b/src/main/java/com/backend/scrap/repository/MessageScrapRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.data.domain.Sort;
 
 import java.util.List;
 import java.util.Optional;
@@ -19,8 +20,6 @@ public interface MessageScrapRepository extends JpaRepository<MessageScrap, Long
 
     Optional<MessageScrap> findByMemberAndMessage(Member member, Message message);
     List<MessageScrap> findByMemberAndMessageIn(Member member, List<Message> messages);
-
-    List<MessageScrap> findByMemberOrderByIdDesc(Member member);
 
     @Query("""
     select new com.backend.scrap.dto.ScrappedMessageSummaryDTO(
@@ -58,7 +57,6 @@ public interface MessageScrapRepository extends JpaRepository<MessageScrap, Long
         join Question q on q.room = m.room
         left join q.content c
     where s.member.userId = :userId
-    order by s.scrappedAt desc
     """)
-    List<ScrapMessageDTO> findScrapsByUserId(@Param("userId") String userId);
+    List<ScrapMessageDTO> findScrapsByUserId(@Param("userId") String userId, Sort sort);
 }

--- a/src/main/java/com/backend/scrap/service/MessageScrapService.java
+++ b/src/main/java/com/backend/scrap/service/MessageScrapService.java
@@ -71,10 +71,16 @@ public class MessageScrapService {
      */
     @Transactional(readOnly = true)
     public List<ScrapMessageDTO> getScraps(String userId, String order) {
-        Sort sort = "oldest".equalsIgnoreCase(order)
-            ? Sort.by(Sort.Direction.ASC, "scrappedAt")   // 오래된 순
-            : Sort.by(Sort.Direction.DESC, "scrappedAt"); // 기본: 최신 순
-        return messageScrapRepository.findScrapsByUserId(userId, sort);
+        Sort sort;
+        if ("oldest".equalsIgnoreCase(order)) {
+            sort = Sort.by(Sort.Direction.ASC, "scrappedAt");   // 오래된 순
+        } else if ("popular".equalsIgnoreCase(order)) {
+            sort = Sort.by(Sort.Direction.DESC, "scrapCount"); // 인기순 (스크랩 수 내림차순)
+        } else {
+            sort = Sort.by(Sort.Direction.DESC, "scrappedAt"); // 기본: 최신 순
+        }
+        PageRequest pageRequest = PageRequest.of(0, Integer.MAX_VALUE, sort);
+        return messageScrapRepository.findScrapsByUserId(userId, pageRequest).getContent();
     }
 
     /**

--- a/src/main/java/com/backend/scrap/service/MessageScrapService.java
+++ b/src/main/java/com/backend/scrap/service/MessageScrapService.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.backend.scrap.dto.ScrappedMessageSummaryDTO;
 import org.springframework.data.domain.PageRequest;
-
+import org.springframework.data.domain.Sort;
 
 import java.util.List;
 
@@ -70,8 +70,11 @@ public class MessageScrapService {
      * 스크랩 목록 조회
      */
     @Transactional(readOnly = true)
-    public List<ScrapMessageDTO> getScraps(String userId) {
-        return messageScrapRepository.findScrapsByUserId(userId);
+    public List<ScrapMessageDTO> getScraps(String userId, String order) {
+        Sort sort = "oldest".equalsIgnoreCase(order)
+            ? Sort.by(Sort.Direction.ASC, "scrappedAt")   // 오래된 순
+            : Sort.by(Sort.Direction.DESC, "scrappedAt"); // 기본: 최신 순
+        return messageScrapRepository.findScrapsByUserId(userId, sort);
     }
 
     /**


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #113 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
### 1) 내 질문 목록 (`/api/v1/questions/my`)
- 기존: 정렬 없음  
- 변경: `order=latest|oldest|popular` 지원  

Popular 기준: `currentParticipants` 기준 내림차순

---

### 2) 참여한 질문 목록 (`/api/v1/questions?sort=...`)
- 기존: 참여 상태에 따라 목록 불러오기만 가능  
- 변경:
  - 기존 sort(참여/ready/finish)는 유지
  - 여기에 정렬 옵션 `order=...` 추가

Popular 기준: `currentParticipants` 기준 내림차순

---

### 3) 스크랩 목록
- 기존: 최신순만 가능  
- 변경:
  - 동일하게 `order=latest|oldest|popular` 옵션 추가  
  - Popular 기준: 스크랩 수(`scrapCount`) 기반 내림차순


## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
