### PR TITLE
[FEAT] 질문 상세 조회에 myParticipationStatus 추가

### DIFF
--- a/src/main/java/com/backend/question/controller/QuestionController.java
+++ b/src/main/java/com/backend/question/controller/QuestionController.java
@@ -57,8 +57,15 @@ public class QuestionController {
     }
 
     @GetMapping("/{questionId}")
-    public ResponseEntity<QuestionDetailResponseDTO> getQuestionDetailById(@PathVariable Long questionId) {
-        QuestionDetailResponseDTO responseDTO = questionService.getQuestionDetailById(questionId);
+    public ResponseEntity<QuestionDetailResponseDTO> getQuestionDetailById(
+            @AuthenticationPrincipal CustomUserPrincipal me,
+            @PathVariable Long questionId
+    ) {
+        String userId = (me != null) ? me.getUserId() : null;
+    
+        QuestionDetailResponseDTO responseDTO =
+                questionService.getQuestionDetailById(questionId, userId);
+    
         return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
     }
 

--- a/src/main/java/com/backend/question/dto/response/QuestionDetailResponseDTO.java
+++ b/src/main/java/com/backend/question/dto/response/QuestionDetailResponseDTO.java
@@ -2,6 +2,7 @@ package com.backend.question.dto.response;
 
 import com.backend.category.domain.Category;
 import com.backend.question.domain.Question;
+import com.backend.question.domain.ParticipationStatus; 
 import com.backend.tag.Tag;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
@@ -24,9 +25,10 @@ public record QuestionDetailResponseDTO(
         Integer maxParticipants,
         Integer currentParticipants,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        ParticipationStatus myParticipationStatus
 ) {
-    public static QuestionDetailResponseDTO from(Question question, List<Tag> tags, Category mainCategory, Category subCategory) {
+    public static QuestionDetailResponseDTO from(Question question, List<Tag> tags, Category mainCategory, Category subCategory, ParticipationStatus myParticipationStatus) {
         List<String> tagNames = tags.stream()
                 .map(Tag::getName)
                 .toList();
@@ -45,6 +47,7 @@ public record QuestionDetailResponseDTO(
                 subCategory.getName(),
                 question.getMaxParticipants(),
                 question.getCurrentParticipants(),
-                question.getCreatedAt());
+                question.getCreatedAt(),
+                myParticipationStatus);
     }
 }

--- a/src/main/java/com/backend/question/service/QuestionService.java
+++ b/src/main/java/com/backend/question/service/QuestionService.java
@@ -222,22 +222,48 @@ public class QuestionService {
         return questionDtoAssembler.toListDto(questions, myStatusMap);
     }
     //TODO: N+1 문제 해결
-    public QuestionDetailResponseDTO getQuestionDetailById(Long questionId) {
+    public QuestionDetailResponseDTO getQuestionDetailById(Long questionId, String userId) {
         Question question = questionRepository.findById(questionId)
                 .orElseThrow(() -> new RuntimeException("question not found"));
-
+    
         List<Tag> tags = tagQuestionRepository.findAllByQuestion(question)
                 .stream()
                 .map(TagQuestion::getTag)
                 .toList();
-
+    
         CategoryContent categoryContent  = categoryContentRepository.findByContent(question.getContent())
                 .orElseThrow(() -> new RuntimeException("category 찾을 수 없음"));
-
+    
         Category subCategory = categoryContent.getCategory();
         Category mainCategory = subCategory.getParent();
-
-        return QuestionDetailResponseDTO.from(question, tags, mainCategory, subCategory);
+    
+        ParticipationStatus myStatus = ParticipationStatus.NONE;
+    
+        if (userId != null) {
+            Member me = memberRepository.findByUserId(userId)
+                    .orElseThrow(() -> new RuntimeException("member not found"));
+    
+            Room room = question.getRoom();
+    
+            boolean isRoomMember = roomMemberRepository.existsByRoomAndMember(room, me);
+    
+            if (isRoomMember) {
+                // 🔹 ACTIVE면 JOINED, 그 외(RECRUITING/READY_CHECK)는 WAITING
+                if (question.getStatus() == QuestionStatus.ACTIVE) {
+                    myStatus = ParticipationStatus.JOINED;
+                } else {
+                    myStatus = ParticipationStatus.WAITING;
+                }
+            }
+        }
+    
+        return QuestionDetailResponseDTO.from(
+                question,
+                tags,
+                mainCategory,
+                subCategory,
+                myStatus
+        );
     }
 
     //TODO: 진행중이거나 끝났을 땐 못하게 막아야함

--- a/src/main/java/com/backend/question/service/QuestionService.java
+++ b/src/main/java/com/backend/question/service/QuestionService.java
@@ -251,7 +251,8 @@ public class QuestionService {
                 // 🔹 ACTIVE면 JOINED, 그 외(RECRUITING/READY_CHECK)는 WAITING
                 if (question.getStatus() == QuestionStatus.ACTIVE) {
                     myStatus = ParticipationStatus.JOINED;
-                } else {
+                } else if (question.getStatus() == QuestionStatus.RECRUITING ||
+                           question.getStatus() == QuestionStatus.READY_CHECK) {
                     myStatus = ParticipationStatus.WAITING;
                 }
             }


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #115 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
질문 상세 조회 API (`GET /api/v1/questions/{questionId}`) 응답에  
사용자의 참여 상태(`myParticipationStatus`)를 추가했습니다.

- 비로그인 사용자는 `NONE`
- 로그인 + 해당 질문 방 미참여 → `NONE`
- 로그인 + 해당 질문 방 참여 중
  - 질문 상태가 `ACTIVE` → `JOINED`
  - 그 외(`RECRUITING`, `READY_CHECK` 등) → `WAITING`

을 반환하도록 구현했습니다.

## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
