### PR TITLE
[REFACT] 질문 목록/검색 API에 좋아요 정보(likeCount, isLikedByMe) 통합

### DIFF
--- a/src/main/java/com/backend/like/repository/QuestionLikeRepository.java
+++ b/src/main/java/com/backend/like/repository/QuestionLikeRepository.java
@@ -16,10 +16,6 @@ public interface QuestionLikeRepository extends JpaRepository<QuestionLike, Long
 
     void deleteByQuestionAndMember(Question question, Member member);
 
-    long countByQuestion_Id(Long questionId);
-
-    boolean existsByQuestion_IdAndMember_UserId(Long questionId, String userId);
-
     @Query("""
         SELECT ql.question.id AS questionId,
                COUNT(allLikes.id) AS likeCount
@@ -30,4 +26,15 @@ public interface QuestionLikeRepository extends JpaRepository<QuestionLike, Long
         GROUP BY ql.question.id
         """)
     List<QuestionLikeSummary> findLikedQuestionIdsWithCountsByUserId(@Param("userId") String userId);
+
+    @Query("""
+        select ql.question.id 
+        from QuestionLike ql
+        where ql.member.userId = :userId
+        and ql.question.id in :questionIds
+        """)
+    List<Long> findLikedQuestionIds(
+            @Param("userId") String userId,
+            @Param("questionIds") List<Long> questionIds
+    );
 }

--- a/src/main/java/com/backend/like/service/QuestionLikeService.java
+++ b/src/main/java/com/backend/like/service/QuestionLikeService.java
@@ -36,9 +36,10 @@ public class QuestionLikeService {
 
         if (!likeRepository.existsByQuestionAndMember(question, member)) {
             likeRepository.save(new QuestionLike(question, member));
+            question.increaseLikeCount();
         }
 
-        return likeRepository.countByQuestion_Id(questionId);
+        return question.getLikeCount();
     }
 
     /**
@@ -52,9 +53,12 @@ public class QuestionLikeService {
         Member member = memberRepository.findByUserId(userId)
                 .orElseThrow(() -> new AuthError("invalid_user", "존재하지 않는 회원입니다."));
 
-        likeRepository.deleteByQuestionAndMember(question, member);
+        if (likeRepository.existsByQuestionAndMember(question, member)) {
+                likeRepository.deleteByQuestionAndMember(question, member);
+                question.decreaseLikeCount();
+                }
 
-        return likeRepository.countByQuestion_Id(questionId);
+        return question.getLikeCount();
     }
 
     /**
@@ -62,10 +66,10 @@ public class QuestionLikeService {
      */
     @Transactional(readOnly = true)
     public long getLikeCount(Long questionId) {
-        questionRepository.findById(questionId)
+        Question question = questionRepository.findById(questionId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 질문입니다. id=" + questionId));
-                
-        return likeRepository.countByQuestion_Id(questionId);
+
+        return question.getLikeCount();
     }
 
     /**

--- a/src/main/java/com/backend/question/domain/Question.java
+++ b/src/main/java/com/backend/question/domain/Question.java
@@ -66,6 +66,17 @@ public class Question extends BaseTimeEntity {
         this.currentParticipants--;
     }
 
+    @Column(name = "like_count", nullable = false)
+    private int likeCount = 0;
+
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        if (this.likeCount > 0) this.likeCount--;
+    }
+
 
     public void recruitingToReadyCheck() {
         if (this.status != QuestionStatus.RECRUITING) {

--- a/src/main/java/com/backend/question/dto/response/QuestionResponseDTO.java
+++ b/src/main/java/com/backend/question/dto/response/QuestionResponseDTO.java
@@ -30,10 +30,19 @@ public record QuestionResponseDTO(
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime createdAt,
 
-        ParticipationStatus myParticipationStatus
+        ParticipationStatus myParticipationStatus,
+        Integer likeCount,
+        Boolean isLikedByMe
         )
 {
-    public static QuestionResponseDTO from(Question question, Category subCategory, List<Tag> tags, ParticipationStatus myStatus) {
+    public static QuestionResponseDTO from(
+                Question question,
+                Category subCategory,
+                List<Tag> tags,
+                ParticipationStatus myStatus,
+                Integer likeCount,
+                Boolean isLikedByMe
+        ) {
         List<String> tagNames = tags.stream()
                 .map(Tag::getName)
                 .toList();
@@ -64,7 +73,9 @@ public record QuestionResponseDTO(
                 question.getCurrentParticipants(),
                 tagNames,
                 question.getCreatedAt(),
-                myStatus
+                myStatus,
+                likeCount,
+                isLikedByMe
         );
     }
 }

--- a/src/main/java/com/backend/question/service/QuestionDtoAssembler.java
+++ b/src/main/java/com/backend/question/service/QuestionDtoAssembler.java
@@ -25,23 +25,35 @@ public class QuestionDtoAssembler {
     private final TagQuestionRepository tagQuestionRepository;
     private final CategoryContentRepository categoryContentRepository;
 
-    public Page<QuestionResponseDTO> toPageDto(Page<Question> questionPage, Map<Long, ParticipationStatus> myStatusMap
+    public Page<QuestionResponseDTO> toPageDto(
+            Page<Question> questionPage,
+            Map<Long, ParticipationStatus> myStatusMap,
+            Map<Long, Integer> likeCountMap,
+            Map<Long, Boolean> isLikedByMeMap
     ) {
         List<Question> questions = questionPage.getContent();
-
         Map<Long, List<Tag>> questionTagMap = getQuestionTagMap(questions);
         Map<Long, Category> contentCategoryMap = getContentCategoryMap(questions);
+        
         
         return questionPage.map(question -> {
             List<Tag> tags = questionTagMap.getOrDefault(question.getId(), Collections.emptyList());
             Category category = contentCategoryMap.get(question.getContent().getId());
             ParticipationStatus myStatus = myStatusMap.getOrDefault(question.getId(), ParticipationStatus.NONE);
+
+            Integer likeCount = likeCountMap.getOrDefault(question.getId(), 0);
+            Boolean isLiked = isLikedByMeMap.getOrDefault(question.getId(), false);
             
-            return QuestionResponseDTO.from(question, category, tags, myStatus);
+            return QuestionResponseDTO.from(question, category, tags, myStatus, likeCount, isLiked);
         });
     }
 
-    public List<QuestionResponseDTO> toListDto(List<Question> questions, Map<Long, ParticipationStatus> myStatusMap) {
+    public List<QuestionResponseDTO> toListDto(
+            List<Question> questions,
+            Map<Long, ParticipationStatus> myStatusMap,
+            Map<Long, Integer> likeCountMap,
+            Map<Long, Boolean> isLikedByMeMap
+        ) {
         if (questions.isEmpty()) {
             return Collections.emptyList();
         }
@@ -56,8 +68,11 @@ public class QuestionDtoAssembler {
                     List<Tag> tags = questionTagMap.getOrDefault(question.getId(), Collections.emptyList());
                     Category category = contentCategoryMap.get(question.getContent().getId());
                     ParticipationStatus myStatus = myStatusMap.getOrDefault(question.getId(), ParticipationStatus.NONE);
+                    
+                    Integer likeCount = likeCountMap.getOrDefault(question.getId(), 0);
+                    Boolean isLiked = isLikedByMeMap.getOrDefault(question.getId(), false);
 
-                    return QuestionResponseDTO.from(question, category, tags, myStatus);
+                    return QuestionResponseDTO.from(question, category, tags, myStatus, likeCount, isLiked);
                 })
                 .toList();
     }

--- a/src/main/java/com/backend/question/service/QuestionService.java
+++ b/src/main/java/com/backend/question/service/QuestionService.java
@@ -22,6 +22,7 @@ import com.backend.question.dto.response.QuestionDTO;
 import com.backend.question.dto.response.QuestionDetailResponseDTO;
 import com.backend.question.dto.response.QuestionResponseDTO;
 import com.backend.question.repository.QuestionRepository;
+import com.backend.like.repository.QuestionLikeRepository;
 import com.backend.room.domain.Room;
 import com.backend.room.repository.RoomRepository;
 import com.backend.roomMember.domain.RoomMember;
@@ -41,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.Comparator;
+import java.util.Collections;
 
 @Service
 @RequiredArgsConstructor
@@ -58,6 +60,7 @@ public class QuestionService {
     private final NotificationPublisher notificationPublisher;
     private final NotificationRepository notificationRepository;
     private final CategoryContentRepository categoryContentRepository;
+    private final QuestionLikeRepository likeRepository;
 
     @Transactional
     public CreateQuestionResponseDTO createFirstQuestion(String hostUserId, CreateFirstQuestionRequestDTO dto) {
@@ -186,7 +189,24 @@ public class QuestionService {
                 q -> ParticipationStatus.JOINED
         ));
 
-        return questionDtoAssembler.toListDto(ordered, myStatusMap);
+        Map<Long, Integer> likeCountMap = questions.stream()
+        .collect(Collectors.toMap(
+                Question::getId,
+                Question::getLikeCount
+        ));
+
+        List<Long> questionIds = questions.stream().map(Question::getId).toList();
+        List<Long> likedIds = likeRepository.findLikedQuestionIds(userId, questionIds);
+
+        Map<Long, Boolean> isLikedByMeMap = likedIds.stream()
+                .collect(Collectors.toMap(id -> id, id -> true));
+
+        return questionDtoAssembler.toListDto(
+                ordered,
+                myStatusMap,
+                likeCountMap,
+                isLikedByMeMap
+        );
     }
 
     public List<QuestionResponseDTO> getQuestions(String userId, String sort, String order) {
@@ -250,7 +270,24 @@ public class QuestionService {
                         }
                 ));
 
-        return questionDtoAssembler.toListDto(ordered, myStatusMap);
+        Map<Long, Integer> likeCountMap = questions.stream()
+        .collect(Collectors.toMap(
+                Question::getId,
+                Question::getLikeCount
+        ));
+    
+        List<Long> questionIds = questions.stream().map(Question::getId).toList();
+        List<Long> likedIds = likeRepository.findLikedQuestionIds(userId, questionIds);
+    
+        Map<Long, Boolean> isLikedByMeMap = likedIds.stream()
+                .collect(Collectors.toMap(id -> id, id -> true));
+    
+        return questionDtoAssembler.toListDto(
+                ordered,
+                myStatusMap,
+                likeCountMap,
+                isLikedByMeMap
+        );
     }
     //TODO: N+1 문제 해결
     public QuestionDetailResponseDTO getQuestionDetailById(Long questionId) {
@@ -347,6 +384,7 @@ public class QuestionService {
 
     public Page<QuestionResponseDTO> searchQuestions(String userId, QuestionSearchRequestDTO dto, Pageable pageable) {
         Page<Question> questionPage = questionRepository.search(dto, pageable);
+        List<Question> questions = questionPage.getContent();
         Map<Long, ParticipationStatus> myStatusMap = java.util.Collections.emptyMap();
 
         if (userId != null) {
@@ -370,9 +408,28 @@ public class QuestionService {
                     ));
         }
 
+        Map<Long, Integer> likeCountMap = questions.stream()
+        .collect(Collectors.toMap(
+                Question::getId,
+                Question::getLikeCount
+        ));
+
+        Map<Long, Boolean> isLikedByMeMap = Collections.emptyMap();
+
+        if (userId != null) {
+            List<Long> ids = questions.stream().map(Question::getId).toList();
+    
+            List<Long> likedIds = likeRepository.findLikedQuestionIds(userId, ids);
+    
+            isLikedByMeMap = likedIds.stream()
+                    .collect(Collectors.toMap(id -> id, id -> true));
+        }
+
         return questionDtoAssembler.toPageDto(
             questionPage,
-            myStatusMap
+            myStatusMap,
+            likeCountMap,
+            isLikedByMeMap
     );
     }
 }


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #117 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
## 📌 변경 요약
기존에는 Question 목록 및 검색 시 좋아요 정보(likeCount, isLikedByMe)를 위해 별도 API 호출이 필요했음.
이번 PR에서는 좋아요 정보를 QuestionResponseDTO에 직접 포함하여 단일 API로 제공하도록 개선함.

## 🛠 주요 변경 사항
- Question 엔티티에 likeCount 필드 반영
- QuestionLikeService에서 엔티티 기반 like 카운트 증가/감소 처리
- QuestionService → batch 조회 기반 likeCountMap, isLikedMap 계산 추가
- QuestionDtoAssembler에서 새로운 필드를 DTO에 매핑
- QuestionResponseDTO 구조 확장 (likeCount, isLikedByMe)

## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
