### PR TITLE
[REFACTOR] kakao 로그인 시 닉네임 초기화 발생

### DIFF
--- a/src/main/java/com/backend/member/service/KakaoAuthService.java
+++ b/src/main/java/com/backend/member/service/KakaoAuthService.java
@@ -24,10 +24,6 @@ public class KakaoAuthService {
     public Member upsertKakaoUser(String socialId, String email, String nickname, String profileImageUrl) {
         return memberRepo.findBySocialProviderAndSocialId(SocialProvider.KAKAO, socialId)
                 .map(m -> {
-                    // 이메일/프로필/닉네임 최신화(필요시)
-                    if (email != null && !email.equals(m.getEmail())) {
-                        // 이메일 unique라 변경 시 유효성 체크 필요 (케이스에 따라 유지 권장)
-                    }
                     if (nickname != null) m.changeNickname(nickname);
                     if (profileImageUrl != null) m.changeProfile(profileImageUrl);
                     return m;

--- a/src/main/java/com/backend/question/domain/Question.java
+++ b/src/main/java/com/backend/question/domain/Question.java
@@ -66,7 +66,7 @@ public class Question extends BaseTimeEntity {
         this.currentParticipants--;
     }
 
-    @Column(name = "like_count", nullable = false)
+    @Column(name = "like_count", nullable = false, columnDefinition = "int default 0")
     private int likeCount = 0;
 
     public void increaseLikeCount() {

--- a/src/main/java/com/backend/question/service/QuestionService.java
+++ b/src/main/java/com/backend/question/service/QuestionService.java
@@ -195,8 +195,10 @@ public class QuestionService {
                 Question::getLikeCount
         ));
 
-        List<Long> questionIds = questions.stream().map(Question::getId).toList();
-        List<Long> likedIds = likeRepository.findLikedQuestionIds(userId, questionIds);
+        List<Long> questionIds = ordered.stream().map(Question::getId).toList();
+        List<Long> likedIds = questionIds.isEmpty()
+                ? Collections.emptyList()
+                : likeRepository.findLikedQuestionIds(userId, questionIds);
 
         Map<Long, Boolean> isLikedByMeMap = likedIds.stream()
                 .collect(Collectors.toMap(id -> id, id -> true));
@@ -276,8 +278,10 @@ public class QuestionService {
                 Question::getLikeCount
         ));
     
-        List<Long> questionIds = questions.stream().map(Question::getId).toList();
-        List<Long> likedIds = likeRepository.findLikedQuestionIds(userId, questionIds);
+        List<Long> questionIds = ordered.stream().map(Question::getId).toList();
+        List<Long> likedIds = questionIds.isEmpty()
+                ? Collections.emptyList()
+                : likeRepository.findLikedQuestionIds(userId, questionIds);
     
         Map<Long, Boolean> isLikedByMeMap = likedIds.stream()
                 .collect(Collectors.toMap(id -> id, id -> true));
@@ -419,7 +423,9 @@ public class QuestionService {
         if (userId != null) {
             List<Long> ids = questions.stream().map(Question::getId).toList();
     
-            List<Long> likedIds = likeRepository.findLikedQuestionIds(userId, ids);
+            List<Long> likedIds = ids.isEmpty()
+                ? Collections.emptyList()
+                : likeRepository.findLikedQuestionIds(userId, ids);
     
             isLikedByMeMap = likedIds.stream()
                     .collect(Collectors.toMap(id -> id, id -> true));


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #121 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->


## 📚 Reference
### Kakao 소셜 로그인 닉네임 유지 버그 수정
- 카카오 로그인 시 매번 nickname 이 DB 에 덮어씌워지는 문제 해결
- 기존 로직: 카카오 닉네임 → 매번 m.changeNickname() 으로 overwrite
- 수정: 최초 회원가입 때만 카카오 nickname 저장  
  이후 로그인에서는 nickname 변경하지 않도록 정책 변경


### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
